### PR TITLE
Initialise class member values

### DIFF
--- a/duffel_api/client.py
+++ b/duffel_api/client.py
@@ -23,31 +23,43 @@ class Duffel:
         # composition in all of these instead.
         self._kwargs = kwargs
 
+        # Lazily initialise clients by when they're called
+        self.aircraft_client = None
+        self.airport_client = None
+        self.airline_client = None
+        self.offer_request_client = None
+        self.offer_client = None
+        self.order_client = None
+        self.order_cancellation_client = None
+        self.payments_client = None
+        self.seat_map_client = None
+        self.webhook_client = None
+
     @property
     def aircraft(self):
         """Aircraft API - /air/aircraft"""
-        if not hasattr(self, "aircraft_client"):
+        if isinstance(self.aircraft_client, type(None)):
             setattr(self, "aircraft_client", AircraftClient(**self._kwargs))
         return self.aircraft_client
 
     @property
     def airports(self):
         """Airports API - /air/airports"""
-        if not hasattr(self, "airport_client"):
+        if isinstance(self.airport_client, type(None)):
             setattr(self, "airport_client", AirportClient(**self._kwargs))
         return self.airport_client
 
     @property
     def airlines(self):
         """Airlines API - /air/airlines"""
-        if not hasattr(self, "airline_client"):
+        if isinstance(self.airline_client, type(None)):
             setattr(self, "airline_client", AirlineClient(**self._kwargs))
         return self.airline_client
 
     @property
     def offer_requests(self):
         """Offer Requests API - /air/offer_requests"""
-        if not hasattr(self, "offer_request_client"):
+        if isinstance(self.offer_request_client, type(None)):
             setattr(
                 self,
                 "offer_request_client",
@@ -58,21 +70,21 @@ class Duffel:
     @property
     def offers(self):
         """Offers API - /air/offers"""
-        if not hasattr(self, "offer_client"):
+        if isinstance(self.offer_client, type(None)):
             setattr(self, "offer_client", OfferClient(**self._kwargs))
         return self.offer_client
 
     @property
     def orders(self):
         """Orders API - /air/orders"""
-        if not hasattr(self, "order_client"):
+        if isinstance(self.order_client, type(None)):
             setattr(self, "order_client", OrderClient(**self._kwargs))
         return self.order_client
 
     @property
     def order_cancellations(self):
         """Order Cancellations API - /air/order_cancellations"""
-        if not hasattr(self, "order_cancellation_client"):
+        if isinstance(self.order_cancellation_client, type(None)):
             setattr(
                 self,
                 "order_cancellation_client",
@@ -83,20 +95,20 @@ class Duffel:
     @property
     def payments(self):
         """Payments API - /air/payments"""
-        if not hasattr(self, "payment_client"):
-            setattr(self, "payment_client", PaymentClient(**self._kwargs))
-        return self.payment_client
+        if isinstance(self.payments_client, type(None)):
+            setattr(self, "payments_client", PaymentClient(**self._kwargs))
+        return self.payments_client
 
     @property
     def seat_maps(self):
         """Seat Maps API - /air/seat_maps"""
-        if not hasattr(self, "seat_map_client"):
+        if isinstance(self.seat_map_client, type(None)):
             setattr(self, "seat_map_client", SeatMapClient(**self._kwargs))
         return self.seat_map_client
 
     @property
     def webhooks(self):
         """Webhooks API - /air/webhooks (Preview)"""
-        if not hasattr(self, "webhook_client"):
+        if isinstance(self.webhook_client, type(None)):
             setattr(self, "webhook_client", WebhookClient(**self._kwargs))
         return self.webhook_client


### PR DESCRIPTION
This removes "cannot access member member is unknown" warnings.

Change member name to be consistent.
