### PR TITLE
Fix `live_mode` in fixture

### DIFF
--- a/tests/fixtures/create-offer-request.json
+++ b/tests/fixtures/create-offer-request.json
@@ -3,7 +3,7 @@
     "cabin_class": "economy",
     "created_at": "2020-02-12T15:21:01.927Z",
     "id": "orq_00009hjdomFOCJyxHG7k7k",
-    "live_mode": false,
+    "live_mode": true,
     "offers": [
       {
         "allowed_passenger_identity_document_types": [


### PR DESCRIPTION
💁 It's not possible for an API response to have mixed `live_mode` values. This change resolves that.

There's still the open question of whether the fixtures should stick to one value or not but that can be resolved separately.
```
$ ag live_mode tests/fixtures
tests/fixtures/confirm-order-cancellation.json
7:    "live_mode": true,

tests/fixtures/create-order-cancellation.json
7:    "live_mode": true,

tests/fixtures/create-payment-intent.json
14:    "live_mode": true,

tests/fixtures/confirm-payment-intent.json
14:    "live_mode": true,

tests/fixtures/get-payment-intent-by-id.json
14:    "live_mode": true,

tests/fixtures/get-orders.json
27:      "live_mode": false,

tests/fixtures/get-order-cancellations.json
8:      "live_mode": false,

tests/fixtures/get-order-cancellation-by-id.json
7:    "live_mode": false,

tests/fixtures/get-offers.json
24:      "live_mode": true,

tests/fixtures/get-order-by-id.json
27:    "live_mode": true,

tests/fixtures/get-offer-by-id.json
39:    "live_mode": true,

tests/fixtures/update-webhook.json
6:    "live_mode": true,

tests/fixtures/create-offer-request.json
6:    "live_mode": false,
29:        "live_mode": true,

tests/fixtures/get-offer-requests.json
7:      "live_mode": true,
30:          "live_mode": true,

tests/fixtures/create-webhook.json
6:    "live_mode": true,

tests/fixtures/create-order.json
26:    "live_mode": true,

tests/fixtures/get-offer-request-by-id.json
6:    "live_mode": true,
29:        "live_mode": true,

tests/fixtures/update-order-by-id.json
27:    "live_mode": false,
```