### PR TITLE
Use consistent term for access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Once you have the token, you can call `Duffel()` with the value:
 ```python
 from duffel_api import Duffel
 
-api_token = 'test_...'
-client = Duffel(api_token = api_token)
+access_token = 'test_...'
+client = Duffel(access_token = access_token)
 ```
 
 After you have a client you can interact with, you can make calls to the Duffel API:
@@ -34,7 +34,7 @@ After you have a client you can interact with, you can make calls to the Duffel 
 ```python
 from duffel_api import Duffel
 
-client = Duffel(api_token = 'test...')
+client = Duffel(access_token = 'test...')
 
 offer_requests = client.offer_requests.list()
 for offer_request in offer_requests:

--- a/duffel_api/http_client.py
+++ b/duffel_api/http_client.py
@@ -75,7 +75,7 @@ class HttpClient:
     URL = "https://api.duffel.com"
     VERSION = "beta"
 
-    def __init__(self, api_token=None, api_url=None, api_version=None, **settings):
+    def __init__(self, access_token=None, api_url=None, api_version=None, **settings):
         if api_url is not None:
             self._api_url = api_url
         else:
@@ -92,12 +92,12 @@ class HttpClient:
         self.http_session.headers.update({"User-Agent": user_agent})
         self.http_session.headers.update({"Accept": "application/json"})
         self.http_session.headers.update({"Duffel-Version": self._api_version})
-        if not api_token:
-            api_token = os.getenv("DUFFEL_API_TOKEN")
-            if not api_token:
-                raise ClientError("must set DUFFEL_API_TOKEN")
+        if not access_token:
+            access_token = os.getenv("DUFFEL_ACCESS_TOKEN")
+            if not access_token:
+                raise ClientError("must set DUFFEL_ACCESS_TOKEN")
             self.http_session.headers.update(
-                {"Authorization": "Bearer {}".format(api_token)}
+                {"Authorization": "Bearer {}".format(access_token)}
             )
 
     def _http_call(self, endpoint, method, query_params=None, body=None):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -14,8 +14,8 @@ def fixture(name, url_path, mock, status_code, with_response=True):
             response = json.loads(fh.read())
             uri = "{}/{}".format(url, url_path)
             mock(uri, complete_qs=True, json=response, status_code=status_code)
-            yield Duffel(api_token="some_token", api_url=url)
+            yield Duffel(access_token="some_token", api_url=url)
         else:
             uri = "{}/{}".format(url, url_path)
             mock(uri, complete_qs=True, status_code=status_code)
-            yield Duffel(api_token="some_token", api_url=url)
+            yield Duffel(access_token="some_token", api_url=url)


### PR DESCRIPTION
We use access token throughout our API reference and guides and also our web app.