### PR TITLE
Assign code owners (FLAPI-2026)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # See https://help.github.com/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 # for more information about the format and syntax of this file
 
-* @duffelhq/engineering
+* @duffelhq/flights-api @duffelhq/python-maintainers


### PR DESCRIPTION
💁 This change configures code owners for this repository. I've used the whole of Engineering because there are people with experience writing Python across different teams and using @duffelhq/flights-api didn't seem appropriate. I may well be wrong though so please challenge me on this if you feel otherwise!