### PR TITLE
Update Tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
      pytest
      pytest-cov
      requests-mock[fixture]
-commands = pytest --cov --cov-append
+commands = pytest --cov --cov-append {posargs}
 
 [testenv:linting]
 deps = flake8


### PR DESCRIPTION
💁 These changes apply a few configuration updates that I'd made locally while working on other changes:
* Sets `interrogate` (run during `tax -e doc`) to output the documentation coverage for its file analysis. Without that I found it cumbersome to identify the files which needed to be updated.
* Adds positional arguments to `pytest` (run for every Python version) to allow passing additional arguments. I found that useful when re-running tests for a specific file or test within that file.