### PR TITLE
Update parser for payment requirement fields

### DIFF
--- a/duffel_api/utils.py
+++ b/duffel_api/utils.py
@@ -14,11 +14,15 @@ def maybe_parse_date_entries(key, value):
         "pay_by",
         "confirmed_at",
         "cancelled_at",
-        "price_guarantee_expires_at",
         "synced_at",
-        "payment_required_by",
     ]:
         return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+
+    if key in [
+        "price_guarantee_expires_at",
+        "payment_required_by",
+    ]:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
 
     if key in [
         "departing_at",

--- a/tests/fixtures/create-offer-request.json
+++ b/tests/fixtures/create-offer-request.json
@@ -41,8 +41,8 @@
           }
         ],
         "payment_requirements": {
-          "payment_required_by": "2020-01-17T10:42:14.545Z",
-          "price_guarantee_expires_at": "2020-01-17T10:42:14.545Z",
+          "payment_required_by": "2020-01-17T10:42:14Z",
+          "price_guarantee_expires_at": "2020-01-17T10:42:14Z",
           "requires_instant_payment": false
         },
         "slices": [

--- a/tests/fixtures/create-order.json
+++ b/tests/fixtures/create-order.json
@@ -43,8 +43,8 @@
     ],
     "payment_status": {
       "awaiting_payment": true,
-      "payment_required_by": "2020-01-17T10:42:14.545Z",
-      "price_guarantee_expires_at": "2020-01-17T10:42:14.545Z"
+      "payment_required_by": "2020-01-17T10:42:14Z",
+      "price_guarantee_expires_at": "2020-01-17T10:42:14Z"
     },
     "payments": [
       {

--- a/tests/fixtures/get-offer-by-id.json
+++ b/tests/fixtures/get-offer-by-id.json
@@ -51,8 +51,8 @@
       }
     ],
     "payment_requirements": {
-      "payment_required_by": "2020-01-17T10:42:14.545Z",
-      "price_guarantee_expires_at": "2020-01-17T10:42:14.545Z",
+      "payment_required_by": "2020-01-17T10:42:14Z",
+      "price_guarantee_expires_at": "2020-01-17T10:42:14Z",
       "requires_instant_payment": false
     },
     "slices": [

--- a/tests/fixtures/get-offer-request-by-id.json
+++ b/tests/fixtures/get-offer-request-by-id.json
@@ -41,8 +41,8 @@
           }
         ],
         "payment_requirements": {
-          "payment_required_by": "2020-01-17T10:42:14.545Z",
-          "price_guarantee_expires_at": "2020-01-17T10:42:14.545Z",
+          "payment_required_by": "2020-01-17T10:42:14Z",
+          "price_guarantee_expires_at": "2020-01-17T10:42:14Z",
           "requires_instant_payment": false
         },
         "slices": [

--- a/tests/fixtures/get-offer-requests.json
+++ b/tests/fixtures/get-offer-requests.json
@@ -42,8 +42,8 @@
             }
           ],
           "payment_requirements": {
-            "payment_required_by": "2020-01-17T10:42:14.545Z",
-            "price_guarantee_expires_at": "2020-01-17T10:42:14.545Z",
+            "payment_required_by": "2020-01-17T10:42:14Z",
+            "price_guarantee_expires_at": "2020-01-17T10:42:14Z",
             "requires_instant_payment": false
           },
           "slices": [

--- a/tests/fixtures/get-offers.json
+++ b/tests/fixtures/get-offers.json
@@ -36,8 +36,8 @@
         }
       ],
       "payment_requirements": {
-        "payment_required_by": "2020-01-17T10:42:14.545Z",
-        "price_guarantee_expires_at": "2020-01-17T10:42:14.545Z",
+        "payment_required_by": "2020-01-17T10:42:14Z",
+        "price_guarantee_expires_at": "2020-01-17T10:42:14Z",
         "requires_instant_payment": false
       },
       "slices": [

--- a/tests/fixtures/get-order-by-id.json
+++ b/tests/fixtures/get-order-by-id.json
@@ -54,8 +54,8 @@
     ],
     "payment_status": {
       "awaiting_payment": true,
-      "payment_required_by": "2020-01-17T10:42:14.545Z",
-      "price_guarantee_expires_at": "2020-01-17T10:42:14.545Z"
+      "payment_required_by": "2020-01-17T10:42:14Z",
+      "price_guarantee_expires_at": "2020-01-17T10:42:14Z"
     },
     "services": [
       {

--- a/tests/fixtures/get-orders.json
+++ b/tests/fixtures/get-orders.json
@@ -44,8 +44,8 @@
       ],
       "payment_status": {
         "awaiting_payment": true,
-        "payment_required_by": "2020-01-17T10:42:14.545Z",
-        "price_guarantee_expires_at": "2020-01-17T10:42:14.545Z"
+        "payment_required_by": "2020-01-17T10:42:14Z",
+        "price_guarantee_expires_at": "2020-01-17T10:42:14Z"
       },
       "payments": [
         {

--- a/tests/fixtures/update-order-by-id.json
+++ b/tests/fixtures/update-order-by-id.json
@@ -54,8 +54,8 @@
     ],
     "payment_status": {
       "awaiting_payment": true,
-      "payment_required_by": "2020-01-17T10:42:14.545Z",
-      "price_guarantee_expires_at": "2020-01-17T10:42:14.545Z"
+      "payment_required_by": "2020-01-17T10:42:14Z",
+      "price_guarantee_expires_at": "2020-01-17T10:42:14Z"
     },
     "services": [
       {


### PR DESCRIPTION
💁 Both `payment_required_by` and `price_guarantee_expires_at` are returned
from the API without microsecond precision:

    "payment_requirements": {
      "requires_instant_payment": false,
      "price_guarantee_expires_at": "2021-12-24T11:39:45Z",
      "payment_required_by": "2021-12-25T11:39:45Z"
    },