### PR TITLE
Fix formatting of `synced_at`

### DIFF
--- a/duffel_api/utils.py
+++ b/duffel_api/utils.py
@@ -14,13 +14,13 @@ def maybe_parse_date_entries(key, value):
         "pay_by",
         "confirmed_at",
         "cancelled_at",
-        "synced_at",
     ]:
         return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
 
     if key in [
         "price_guarantee_expires_at",
         "payment_required_by",
+        "synced_at",
     ]:
         return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
 

--- a/tests/fixtures/create-order.json
+++ b/tests/fixtures/create-order.json
@@ -249,6 +249,7 @@
         ]
       }
     ],
+    "synced_at": "2020-04-11T15:48:11Z",
     "tax_amount": "30.20",
     "tax_currency": "GBP",
     "total_amount": "90.80",

--- a/tests/fixtures/get-order-by-id.json
+++ b/tests/fixtures/get-order-by-id.json
@@ -251,7 +251,7 @@
         ]
       }
     ],
-    "synced_at": "2020-04-11T15:48:11.642Z",
+    "synced_at": "2020-04-11T15:48:11Z",
     "tax_amount": "30.20",
     "tax_currency": "GBP",
     "total_amount": "90.80",

--- a/tests/fixtures/get-orders.json
+++ b/tests/fixtures/get-orders.json
@@ -250,6 +250,7 @@
           ]
         }
       ],
+      "synced_at": "2020-04-11T15:48:11Z",
       "tax_amount": "30.20",
       "tax_currency": "GBP",
       "total_amount": "90.80",

--- a/tests/fixtures/update-order-by-id.json
+++ b/tests/fixtures/update-order-by-id.json
@@ -251,7 +251,7 @@
         ]
       }
     ],
-    "synced_at": "2020-04-11T15:48:11.642Z",
+    "synced_at": "2020-04-11T15:48:11Z",
     "tax_amount": "30.20",
     "tax_currency": "GBP",
     "total_amount": "90.80",

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,3 +1,4 @@
+import datetime
 import pytest
 
 from duffel_api.api import OrderCreate, OrderUpdate
@@ -10,6 +11,7 @@ def test_get_order_by_id(requests_mock):
     with fixture("get-order-by-id", url, requests_mock.get, 200) as client:
         order = client.orders.get("id")
         assert order.id == "ord_00009hthhsUZ8W4LxQgkjo"
+        assert order.synced_at == datetime.datetime(2020, 4, 11, 15, 48, 11)
         assert len(order.slices) == 1
         assert len(order.passengers) == 1
         assert not order.live_mode
@@ -35,6 +37,7 @@ def test_get_orders(requests_mock):
         assert len(orders) == 1
         order = orders[0]
         assert order.id == "ord_00009hthhsUZ8W4LxQgkjo"
+        assert order.synced_at == datetime.datetime(2020, 4, 11, 15, 48, 11)
 
 
 def test_create_order(requests_mock):
@@ -61,6 +64,7 @@ def test_create_order(requests_mock):
             .execute()
         )
         assert order.id == "ord_00009hthhsUZ8W4LxQgkjo"
+        assert order.synced_at == datetime.datetime(2020, 4, 11, 15, 48, 11)
         assert len(order.services) == 1
         service = order.services[0]
         assert service.id == "ser_00009UhD4ongolulWd9123"
@@ -124,6 +128,7 @@ def test_update_order(requests_mock):
         )
 
         assert order.id == "ord_00009hthhsUZ8W4LxQgkjo"
+        assert order.synced_at == datetime.datetime(2020, 4, 11, 15, 48, 11)
         assert order.metadata == {
             "customer_prefs": "window seat",
             "payment_intent_id": "pit_00009htYpSCXrwaB9DnUm2",


### PR DESCRIPTION
💁 The [example for `synced_at`](https://duffel.com/docs/api/orders/schema#orders-schema-synced-at) in the API documentation for the `/air/orders` endpoint was incorrect. These changes update the format of this field's value to reflect what is actually returned.