### PR TITLE
Conditionally format `expires_at`

### DIFF
--- a/duffel_api/utils.py
+++ b/duffel_api/utils.py
@@ -10,7 +10,6 @@ def maybe_parse_date_entries(key, value):
     if key in [
         "created_at",
         "updated_at",
-        "expires_at",
         "pay_by",
         "confirmed_at",
         "cancelled_at",
@@ -37,6 +36,15 @@ def maybe_parse_date_entries(key, value):
         # date.fromisoformat(value)
         t = datetime.strptime(value, "%Y-%m-%d")
         return date(t.year, t.month, t.day)
+
+    if key == "expires_at":
+        # There are inconsistent formats used for this field depending on the
+        # endpoint
+        if len(value) == 20:
+            return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+        else:
+            return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+
     return value
 
 

--- a/tests/fixtures/confirm-order-cancellation.json
+++ b/tests/fixtures/confirm-order-cancellation.json
@@ -2,7 +2,7 @@
   "data": {
     "confirmed_at": "2020-01-17T11:51:43.114803Z",
     "created_at": "2020-04-11T15:48:11.642Z",
-    "expires_at": "2020-01-17T10:42:14.545052Z",
+    "expires_at": "2020-04-12T10:42:14Z",
     "id": "ore_00009qzZWzjDipIkqpaUAj",
     "live_mode": false,
     "order_id": "ord_00009hthhsUZ8W4LxQgkjo",

--- a/tests/fixtures/create-order-cancellation.json
+++ b/tests/fixtures/create-order-cancellation.json
@@ -2,7 +2,7 @@
   "data": {
     "confirmed_at": "2020-01-17T11:51:43.114803Z",
     "created_at": "2020-04-11T15:48:11.642Z",
-    "expires_at": "2020-01-17T10:42:14.545052Z",
+    "expires_at": "2020-04-12T10:42:14Z",
     "id": "ore_00009qzZWzjDipIkqpaUAj",
     "live_mode": false,
     "order_id": "ord_00009hthhsUZ8W4LxQgkjo",

--- a/tests/fixtures/get-order-change-offer-by-id.json
+++ b/tests/fixtures/get-order-change-offer-by-id.json
@@ -3,7 +3,7 @@
     "change_total_amount": "90.80",
     "change_total_currency": "GBP",
     "created_at": "2020-01-17T10:12:14.545Z",
-    "expires_at": "2020-01-17T10:42:14.545Z",
+    "expires_at": "2020-01-17T10:42:14Z",
     "id": "oco_0000A3vUda8dKRtUSQPSXw",
     "new_total_amount": "35.50",
     "new_total_currency": "GBP",

--- a/tests/fixtures/get-order-change-offers-by-order-change-request-id.json
+++ b/tests/fixtures/get-order-change-offers-by-order-change-request-id.json
@@ -4,7 +4,7 @@
       "change_total_amount": "90.80",
       "change_total_currency": "GBP",
       "created_at": "2020-01-17T10:12:14.545Z",
-      "expires_at": "2020-01-17T10:42:14.545Z",
+      "expires_at": "2020-01-17T10:42:14Z",
       "id": "oco_0000A3vUda8dKRtUSQPSXw",
       "new_total_amount": "35.50",
       "new_total_currency": "GBP",

--- a/tests/test_order_change_offers.py
+++ b/tests/test_order_change_offers.py
@@ -15,7 +15,7 @@ def test_get_order_change_offer_by_id(requests_mock):
             2020, 1, 17, 10, 12, 14, 545000
         )
         assert order_change_offer.expires_at == datetime.datetime(
-            2020, 1, 17, 10, 42, 14, 545000
+            2020, 1, 17, 10, 42, 14
         )
         assert order_change_offer.new_total_amount == "35.50"
         assert order_change_offer.new_total_currency == "GBP"


### PR DESCRIPTION
💁 The examples for this field in the API documentation were incorrect. I've updated to reflect the real values which are returned by various API endpoints and account for the inconsistencies.