### PR TITLE
Update badge image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # duffel-api
 
-![Build Status](https://github.com/duffelhq/duffel-api-python/actions/workflows/python.yaml/badge.svg)
+![Build Status](https://github.com/duffelhq/duffel-api-python/actions/workflows/main.yaml/badge.svg)
 
 
 Python client library for the [Duffel API](https://duffel.com/docs/api).


### PR DESCRIPTION
💁 I changed the workflow name as part of https://github.com/duffelhq/duffel-api-python/pull/24 but neglected to change this as well. Mea culpa!

You can see this change working as intended via the preview URL: https://github.com/duffelhq/duffel-api-python/blob/419b6fa50e1b9bcb26527b58a59ae4d5e1fad425/README.md