### PR TITLE
Handle varying formats returned for `confirmed_at` fields

### DIFF
--- a/duffel_api/utils.py
+++ b/duffel_api/utils.py
@@ -11,7 +11,6 @@ def maybe_parse_date_entries(key, value):
         "created_at",
         "updated_at",
         "pay_by",
-        "confirmed_at",
         "cancelled_at",
     ]:
         return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
@@ -37,7 +36,7 @@ def maybe_parse_date_entries(key, value):
         t = datetime.strptime(value, "%Y-%m-%d")
         return date(t.year, t.month, t.day)
 
-    if key == "expires_at":
+    if key in ["confirmed_at", "expires_at"]:
         # There are inconsistent formats used for this field depending on the
         # endpoint
         if len(value) == 20:

--- a/tests/fixtures/confirm-order-change.json
+++ b/tests/fixtures/confirm-order-change.json
@@ -2,7 +2,7 @@
   "data": {
     "change_total_amount": "30.50",
     "change_total_currency": "GBP",
-    "confirmed_at": "2020-01-17T11:51:43.114803Z",
+    "confirmed_at": "2020-01-17T11:51:43Z",
     "created_at": "2020-04-11T15:48:11.642Z",
     "expires_at": "2020-01-17T10:42:14.545052Z",
     "id": "ocr_0000A3tQSmKyqOrcySrGbo",

--- a/tests/fixtures/get-order-change-by-id.json
+++ b/tests/fixtures/get-order-change-by-id.json
@@ -2,7 +2,7 @@
   "data": {
     "change_total_amount": "30.50",
     "change_total_currency": "GBP",
-    "confirmed_at": "2020-01-17T11:51:43.114803Z",
+    "confirmed_at": "2020-01-17T11:51:43Z",
     "created_at": "2020-04-11T15:48:11.642Z",
     "expires_at": "2020-01-17T10:42:14.545052Z",
     "id": "ocr_0000A3tQSmKyqOrcySrGbo",

--- a/tests/test_order_changes.py
+++ b/tests/test_order_changes.py
@@ -15,6 +15,7 @@ def test_get_order_change_by_id(requests_mock):
         assert order_change.id == "ocr_0000A3tQSmKyqOrcySrGbo"
         assert order_change.change_total_amount == "30.50"
         assert order_change.change_total_currency == "GBP"
+        assert order_change.confirmed_at == datetime.datetime(2020, 1, 17, 11, 51, 43)
         assert order_change.created_at == datetime.datetime(
             2020, 4, 11, 15, 48, 11, 642000
         )
@@ -55,9 +56,7 @@ def test_confirm_order_change(requests_mock):
 
         assert order_change.id == "ocr_0000A3tQSmKyqOrcySrGbo"
         assert order_change.order_id == "ord_0000A3tQcCRZ9R8OY0QlxA"
-        assert order_change.confirmed_at == datetime.datetime(
-            2020, 1, 17, 11, 51, 43, 114803
-        )
+        assert order_change.confirmed_at == datetime.datetime(2020, 1, 17, 11, 51, 43)
         assert order_change.refund_to == "voucher"
 
 


### PR DESCRIPTION
💁 The format of `confirmed_at` varies by API endpoint, e.g. `/air/order_changes` returns this field using a different format to `/air/order_cancellations`.