### PR TITLE
Support original form of payment for refunds

### DIFF
--- a/duffel_api/models/order_change_offer.py
+++ b/duffel_api/models/order_change_offer.py
@@ -20,6 +20,7 @@ class OrderChangeOffer:
         "arc_bsp_cash",
         "balance",
         "card",
+        "original_form_of_payment",
         "voucher",
         "awaiting_payment",
     ]

--- a/tests/fixtures/get-order-change-offers-by-order-change-request-id.json
+++ b/tests/fixtures/get-order-change-offers-by-order-change-request-id.json
@@ -11,7 +11,7 @@
       "order_change_id": "oce_0000A4QasEUIjJ6jHKfhHU",
       "penalty_amount": "10.50",
       "penalty_currency": "GBP",
-      "refund_to": "arc_bsp_cash",
+      "refund_to": "original_form_of_payment",
       "slices": {
         "add": [
           {

--- a/tests/test_order_change_offers.py
+++ b/tests/test_order_change_offers.py
@@ -61,3 +61,4 @@ def test_get_order_change_offers(requests_mock):
         assert len(order_change_offers) == 1
         offer = order_change_offers[0]
         assert offer.id == "oco_0000A3vUda8dKRtUSQPSXw"
+        assert offer.refund_to == "original_form_of_payment"


### PR DESCRIPTION
💁 The refund methods returned in API resources like `OrderChangeOffers` differ slightly from forms of payment.