### PR TITLE
Rename `order` method on Payments

### DIFF
--- a/duffel_api/api/booking/payments.py
+++ b/duffel_api/api/booking/payments.py
@@ -35,7 +35,7 @@ class PaymentCreate:
         if payment["type"] not in ["arc_bsp_cash", "balance", "payments"]:
             raise PaymentClient.InvalidPaymentType(payment["type"])
 
-    def order_id(self, order_id):
+    def order(self, order_id):
         self._order_id = order_id
         return self
 

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -15,7 +15,7 @@ def test_create_payment(requests_mock):
         }
         payment = (
             client.payments.create()
-            .order_id("order-id")
+            .order("order-id")
             .payment(payment_details)
             .execute()
         )
@@ -32,7 +32,7 @@ def test_create_payment_with_invalid_payment_details(requests_mock):
             "currency": "GBP",
             "amount": "30.20",
         }
-        payments_create_client = client.payments.create().order_id("order-id")
+        payments_create_client = client.payments.create().order("order-id")
         with pytest.raises(
             PaymentClient.InvalidPayment,
             match="{'currency': 'GBP', 'amount': '30.20'}",


### PR DESCRIPTION
💁 This change renames the `order_id` method on `Payments` to `order`, mainly for ergonomics and to follow other method names like `OfferRequest.cabin_class()`.