### PR TITLE
Update allowed refund types for `OrderChange`, support null `refund_to`

### DIFF
--- a/duffel_api/models/order_change.py
+++ b/duffel_api/models/order_change.py
@@ -18,11 +18,8 @@ class OrderChange:
     """
 
     allowed_refund_types = [
-        "arc_bsp_cash",
-        "balance",
-        "card",
+        "original_form_of_payment",
         "voucher",
-        "awaiting_payment",
     ]
 
     class InvalidRefundType(Exception):
@@ -31,7 +28,11 @@ class OrderChange:
     def __init__(self, json):
         for key in json:
             value = maybe_parse_date_entries(key, json[key])
-            if key == "refund_to" and value not in OrderChange.allowed_refund_types:
+            if (
+                key == "refund_to"
+                and value is not None
+                and value not in OrderChange.allowed_refund_types
+            ):
                 raise OrderChange.InvalidRefundType(value)
             if key == "slices":
                 value = OrderChangeSlices(value)

--- a/tests/fixtures/create-order-change.json
+++ b/tests/fixtures/create-order-change.json
@@ -12,7 +12,7 @@
     "order_id": "ord_0000A3tQcCRZ9R8OY0QlxA",
     "penalty_amount": "15.50",
     "penalty_currency": "GBP",
-    "refund_to": "voucher",
+    "refund_to": null,
     "slices": {
       "add": [
         {

--- a/tests/test_order_changes.py
+++ b/tests/test_order_changes.py
@@ -41,7 +41,7 @@ def test_create_order_change(requests_mock):
         assert order_change.id == "ocr_0000A3tQSmKyqOrcySrGbo"
         assert order_change.order_id == "ord_0000A3tQcCRZ9R8OY0QlxA"
         assert order_change.confirmed_at is None
-        assert order_change.refund_to == "voucher"
+        assert order_change.refund_to is None
 
 
 def test_confirm_order_change(requests_mock):


### PR DESCRIPTION
💁 The `refund_to` field on `OrderChange` is nullable ([docs](https://duffel.com/docs/api/order-changes/schema#order-changes-schema-refund-to)). These changes support that case and update the list of possible refund types.