### PR TITLE
Decrease package version to 0.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="duffel-api",
-    version="1.0.0-rc1",
+    version="0.1.0",
     author="Duffel Engineering",
     author_email="client-libraries@duffel.com",
     description="Client library for the Duffel API",


### PR DESCRIPTION
💁 This change reverts bdd3287952d661d48909d52a66deb84eb0f90c45 to start the version cycle for this package with 0.1.0 (especially as 1.0.0-rc1 was never tagged or published).