### PR TITLE
Test publishing package to PyPI first

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,6 +30,12 @@ jobs:
       run: pip install build tox tox-gh-actions
     - name: Build package
       run: python -m build
+    - name: Test publishing package to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:


### PR DESCRIPTION
💁 Publishing a package version to the test version of PyPI before doing it "for real" to PyPI should catch any potential errors in a relatively safe manner.