### PR TITLE
Add type checking

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -89,3 +89,19 @@ jobs:
       run: tox -e doc
     - name: Check formatting
       run: tox -e format -- --check
+
+  types:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: pip install build tox tox-gh-actions
+    - name: Check with pyright
+      run: tox -e pyright
+    - name: Check with mypy
+      run: tox -e mypy

--- a/duffel_api/models/order.py
+++ b/duffel_api/models/order.py
@@ -53,10 +53,14 @@ class OrderConditions:
 
     def __init__(self, json):
         for key in json:
+            # Bind the value before we go into the control flow for setting it
+            value = None
+
             if key == "change_before_departure":
                 value = OrderConditionChangeBeforeDeparture(json[key])
             elif key == "refund_before_departure":
                 value = OrderConditionRefundBeforeDeparture(json[key])
+
             setattr(self, key, value)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,13 @@ exclude = ["setup.py", "examples"]
 ignore-regex = ["^test_.*"]
 fail-under = 95
 quiet = false
+
+[tool.pyright]
+include = ["duffel_api", "tests", "examples"]
+pythonVersion = "3.9"
+verboseOutput = true # Specifies whether output logs should be verbose. This is useful when diagnosing certain problems like import resolution issues.
+typeCheckingMode = "basic"
+
+[tool.mypy]
+files = ["duffel_api", "tests", "examples"]
+python_version = "3.9"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-# keep this list in sync with .github/workflows/python.yaml
-envlist = clean,py36,py37,py38,py39,report
+# keep this list in sync with .github/workflows/main.yaml
+envlist = clean,py36,py37,py38,py39,pyright,mypy,report
 
 [gh-actions]
 python =
@@ -42,3 +42,21 @@ commands = interrogate --verbose
 deps = black
 skip_install = true
 commands = black . {posargs}
+
+[testenv:mypy]
+deps =
+    mypy
+    types-requests
+commands = mypy {toxinidir}
+
+[testenv:pyright]
+deps = pyright
+commands = pyright
+
+[testenv:types]
+deps =
+    {[testenv:mypy]deps}
+    {[testenv:pyright]deps}
+commands =
+    {[testenv:mypy]commands}
+    {[testenv:pyright]commands}


### PR DESCRIPTION
This adds both pyright and mypy, but only pyright is used in the CI on GitHub, since it's faster.

It's working successfully on here, but it's important to note that the PyPy package for pyright is a wrapper around the npm module.

There's quite a lot of errors/warnings as of when first adding this type checking in this PR. We'll get this in so that people can start relying on it to fix them.