### PR TITLE
[FLAPI-2040] Fix various models type hints when maybe parsing

### DIFF
--- a/duffel_api/models/offer.py
+++ b/duffel_api/models/offer.py
@@ -22,21 +22,35 @@ class Offer:
 
     def __init__(self, json):
         for key in json:
-            value = maybe_parse_date_entries(key, json[key])
-            if key == "allowed_passenger_identity_document_types":
-                Offer._validate_passenger_identity_document_types(value)
-            elif key == "conditions":
-                value = OfferConditions(value)
-            elif key == "slices":
-                value = [OfferSlice(v) for v in value]
-            elif key == "passengers":
-                value = [Passenger(v) for v in value]
-            elif key == "payment_requirements":
-                value = PaymentRequirements(value)
-            elif key == "available_services":
-                value = [Service(v) for v in value]
-            elif key == "owner":
-                value = Airline(value)
+            value = json[key]
+
+            if isinstance(value, str):
+                value = maybe_parse_date_entries(key, json[key])
+
+                if key == "allowed_passenger_identity_document_types":
+                    Offer._validate_passenger_identity_document_types(value)
+
+                setattr(self, key, value)
+                continue
+
+            if isinstance(value, dict):
+                if key == "conditions":
+                    value = OfferConditions(value)
+                elif key == "owner":
+                    value = Airline(value)
+                setattr(self, key, value)
+                continue
+
+            if isinstance(value, list):
+                if key == "slices":
+                    value = [OfferSlice(v) for v in value]
+                elif key == "passengers":
+                    value = [Passenger(v) for v in value]
+                elif key == "payment_requirements":
+                    value = PaymentRequirements(value)
+                elif key == "available_services":
+                    value = [Service(v) for v in value]
+
             setattr(self, key, value)
 
     @staticmethod
@@ -55,6 +69,8 @@ class OfferConditions:
 
     def __init__(self, json):
         for key in json:
+            value = json[key]
+
             if key == "change_before_departure":
                 if not json[key] is None:
                     value = OfferConditionChangeBeforeDeparture(json[key])
@@ -166,14 +182,23 @@ class OfferSlice:
 
     def __init__(self, json):
         for key in json:
-            value = maybe_parse_date_entries(key, json[key])
-            if key in ["destination", "origin"]:
-                value = Place(value)
-            elif key in ["destination_type", "origin_type"]:
-                if value not in OfferSlice.allowed_place_types:
-                    raise OfferSlice.InvalidPlaceType(value)
-            elif key == "segments":
+            value = json[key]
+
+            if isinstance(value, str):
+                value = maybe_parse_date_entries(key, json[key])
+
+                if key in ["destination", "origin"]:
+                    value = Place(value)
+                elif key in ["destination_type", "origin_type"]:
+                    if value not in OfferSlice.allowed_place_types:
+                        raise OfferSlice.InvalidPlaceType(value)
+
+                setattr(self, key, value)
+                continue
+
+            if key == "segments":
                 value = [OfferSliceSegment(v) for v in value]
+
             # TODO(nlopes): maybe convert duration to a timedelta or Duration
             setattr(self, key, value)
 
@@ -185,15 +210,25 @@ class OfferSliceSegment:
 
     def __init__(self, json):
         for key in json:
-            value = maybe_parse_date_entries(key, json[key])
-            if key == "aircraft" and value:
-                value = Aircraft(value)
-            elif key in ["marketing_carrier", "operating_carrier"] and value:
-                value = Airline(value)
-            elif key in ["destination", "origin"]:
-                value = Place(value)
-            elif key == "passengers":
-                value = [OfferSliceSegmentPassenger(p) for p in value]
+            value = json[key]
+
+            if isinstance(value, str):
+                value = maybe_parse_date_entries(key, json[key])
+                setattr(self, key, value)
+                continue
+
+            if isinstance(value, dict):
+                if key == "aircraft" and value:
+                    value = Aircraft(value)
+                elif key in ["marketing_carrier", "operating_carrier"] and value:
+                    value = Airline(value)
+                elif key in ["destination", "origin"]:
+                    value = Place(value)
+
+            if isinstance(value, list):
+                if key == "passengers":
+                    value = [OfferSliceSegmentPassenger(p) for p in value]
+
             setattr(self, key, value)
 
 

--- a/duffel_api/models/offer_request.py
+++ b/duffel_api/models/offer_request.py
@@ -12,13 +12,21 @@ class OfferRequest:
 
     def __init__(self, json):
         for key in json:
-            value = maybe_parse_date_entries(key, json[key])
-            if key == "offers":
-                value = [Offer(v) for v in value]
-            elif key == "passengers":
-                value = [Passenger(v) for v in value]
-            elif key == "slices":
-                value = [Slice(v) for v in value]
+            value = json[key]
+
+            if isinstance(value, str):
+                value = maybe_parse_date_entries(key, json[key])
+                setattr(self, key, value)
+                continue
+
+            if isinstance(value, list):
+                if key == "offers":
+                    value = [Offer(v) for v in value]
+                elif key == "passengers":
+                    value = [Passenger(v) for v in value]
+                elif key == "slices":
+                    value = [Slice(v) for v in value]
+
             setattr(self, key, value)
 
 

--- a/duffel_api/models/order.py
+++ b/duffel_api/models/order.py
@@ -1,9 +1,9 @@
 from ..models import (
-    Airline,
-    Place,
     Aircraft,
+    Airline,
     OfferConditionChangeBeforeDeparture,
     OfferConditionRefundBeforeDeparture,
+    Place,
 )
 from ..utils import maybe_parse_date_entries
 

--- a/duffel_api/models/order_change_request.py
+++ b/duffel_api/models/order_change_request.py
@@ -10,12 +10,21 @@ class OrderChangeRequest:
 
     def __init__(self, json):
         for key in json:
-            value = maybe_parse_date_entries(key, json[key])
+            value = json[key]
 
-            if key == "order_change_offers":
-                value = [OrderChangeOffer(v) for v in value]
-            elif key == "slices":
-                value = OrderChangeRequestSlice(value)
+            if isinstance(value, str):
+                value = maybe_parse_date_entries(key, json[key])
+                setattr(self, key, value)
+                continue
+
+            if isinstance(value, dict):
+                if key == "slices":
+                    value = OrderChangeRequestSlice(value)
+
+            if isinstance(value, list):
+                if key == "order_change_offers":
+                    value = [OrderChangeOffer(v) for v in value]
+
             setattr(self, key, value)
 
 

--- a/duffel_api/utils.py
+++ b/duffel_api/utils.py
@@ -1,12 +1,13 @@
 """Assorted auxiliary functions"""
-from datetime import datetime, date
+from datetime import date, datetime
+from typing import Any, Union
 
 
-def maybe_parse_date_entries(key, value):
-    """Parse datetime entries, depending on the value of `key`"""
-    if value is None:
+def maybe_parse_date_entries(key: str, value: Any) -> Union[str, datetime, date]:
+    """Parse appropriate datetime or date entries, depending on the value of `key`"""
+    if not isinstance(value, str):
+        # If it's not a string, don't attempt any parsing
         return value
-
     if key in [
         "created_at",
         "updated_at",
@@ -44,6 +45,7 @@ def maybe_parse_date_entries(key, value):
         else:
             return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
 
+    # All other strings
     return value
 
 

--- a/tests/fixtures/create-hold-order.json
+++ b/tests/fixtures/create-hold-order.json
@@ -46,15 +46,6 @@
       "payment_required_by": "2020-01-17T10:42:14Z",
       "price_guarantee_expires_at": "2020-01-17T10:42:14Z"
     },
-    "payments": [
-      {
-        "amount": "30.20",
-        "created_at": "2020-04-11T15:48:11.642Z",
-        "currency": "GBP",
-        "id": "pay_00009hthhsUZ8W4LxQgkjo",
-        "type": "balance"
-      }
-    ],
     "services": [
       {
         "id": "ser_00009UhD4ongolulWd9123",

--- a/tests/fixtures/create-instant-order.json
+++ b/tests/fixtures/create-instant-order.json
@@ -46,15 +46,6 @@
       "payment_required_by": null,
       "price_guarantee_expires_at": null
     },
-    "payments": [
-      {
-        "amount": "30.20",
-        "created_at": "2020-04-11T15:48:11.642Z",
-        "currency": "GBP",
-        "id": "pay_00009hthhsUZ8W4LxQgkjo",
-        "type": "balance"
-      }
-    ],
     "services": [
       {
         "id": "ser_00009UhD4ongolulWd9123",

--- a/tests/fixtures/get-orders.json
+++ b/tests/fixtures/get-orders.json
@@ -47,15 +47,6 @@
         "payment_required_by": "2020-01-17T10:42:14Z",
         "price_guarantee_expires_at": "2020-01-17T10:42:14Z"
       },
-      "payments": [
-        {
-          "amount": "30.20",
-          "created_at": "2020-04-11T15:48:11.642Z",
-          "currency": "GBP",
-          "id": "pay_00009hthhsUZ8W4LxQgkjo",
-          "type": "balance"
-        }
-      ],
       "services": [
         {
           "id": "ser_00009UhD4ongolulWd9123",

--- a/tests/test_offer.py
+++ b/tests/test_offer.py
@@ -5,5 +5,5 @@ from .fixtures import raw_fixture
 
 def test_offer_model_parsing():
     name = "get-offer-by-id"
-    with raw_fixture(name) as data:
-        assert Offer(data)
+    with raw_fixture(name) as fixture:
+        assert Offer(fixture["data"])


### PR DESCRIPTION
Fix Order model type hints

By (possibly) setting the `value` varaible to a non-iterable type, we get warnings. Instead, explicitly continue on once we maybe parse a `str` type. We wouldn't want to iterate over a `str`.

We don't serialise `Payment`s for `Order`s so I've removed them from the appropriate fixtures.

**TODO**

- [X] Rebase fixup commits
- [x] Fix complexity warnings
