### PR TITLE
[FLAPI-2040] Fix HTTP client API error usage

### DIFF
--- a/duffel_api/http_client.py
+++ b/duffel_api/http_client.py
@@ -1,6 +1,8 @@
 """Http Client, api response and error management"""
 import os
-from requests import Session, Request, codes as http_codes
+
+from requests import Request, Session
+from requests import codes as http_codes
 
 from .utils import version
 

--- a/duffel_api/http_client.py
+++ b/duffel_api/http_client.py
@@ -14,7 +14,7 @@ class ClientError(Exception):
 class ApiError(Exception):
     """An error originated from the API"""
 
-    def __init__(self, headers, json, message=None):
+    def __init__(self, headers, json):
         self._headers = headers
         self.meta = json["meta"]
         self.errors = json["errors"]

--- a/duffel_api/http_client.py
+++ b/duffel_api/http_client.py
@@ -46,7 +46,9 @@ class Pagination:
         self._caller = caller
 
         if params["limit"] > 200:
-            raise ApiError("limit exceeds 200")
+            # We're vaguely faking the structure of the error structure returned
+            # from the API.
+            raise ApiError([], {"errors": [{"message": "limit exceeds 200"}]})
         self._params = params
 
     def __iter__(self):


### PR DESCRIPTION
The arguments are now the appropriate header list (though empty) and error (as a list).

The `message` argument is removed too as we implicitly get it from the first error.