### PR TITLE
Remove unused Tox environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # keep this list in sync with .github/workflows/main.yaml
-envlist = clean,py36,py37,py38,py39,pyright,mypy,report
+envlist = clean,py36,py37,py38,py39,report
 
 [gh-actions]
 python =


### PR DESCRIPTION
We don't need environments for those 2 commands.

```
ERROR:   pyright: undefined
ERROR:   mypy: undefined
```
