### PR TITLE
Update supported Python versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: pip install build tox tox-gh-actions
     - name: Build package
@@ -53,7 +53,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install local version of package
       run: pip install --editable .
     - name: Run search and book example

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Python client library for the [Duffel API](https://duffel.com/docs/api).
 
 ## Requirements
 
-- Python 3.6+
+- Python 3.7+
 
 ## Getting started
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
         "Intended Audience :: Developers",
     ],
     keywords="duffel api flights airports airlines aircraft",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=["requests>=2.25"],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 # keep this list in sync with .github/workflows/main.yaml
-envlist = clean,py36,py37,py38,py39,py310,report
+envlist = clean,py37,py38,py39,py310,report
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # keep this list in sync with .github/workflows/main.yaml
-envlist = clean,py36,py37,py38,py39,report
+envlist = clean,py36,py37,py38,py39,py310,report
 
 [gh-actions]
 python =
@@ -8,6 +8,7 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [testenv]
 deps =


### PR DESCRIPTION
💁 These changes contain 3 significant actions:
1. Add support for Python 3.10, this was released on 2021-10-04: https://www.python.org/dev/peps/pep-0619/#schedule
2. Remove support for Python 3.6, this release reached end-of-life on 2021-12-23: https://www.python.org/dev/peps/pep-0494/#lifespan
3. Set Python 3.7 as the minimum supported version.