### PR TITLE
[FLAPI-2083] Refactor lazy client evaluation

### DIFF
--- a/duffel_api/client.py
+++ b/duffel_api/client.py
@@ -17,6 +17,28 @@ from .api import (
 )
 
 
+def lazy_property(func):
+    """Decorator that makes a property lazy-evaluated"""
+    attr_name = "_lazy_" + func.__name__
+
+    @property
+    def _lazy_property(self):
+        """Function for property lazy-evaluate decorator"""
+        if not hasattr(self, attr_name):
+            # The attr doesn't exist yet, so call the function (`func`) that has
+            # the decorator. The result of that call is set in the attr.
+            #
+            # It's okay to set (read: memoise) the client as an attr since we
+            # each call to the client's functions (e.g. `list`) are not
+            # memoised.
+            setattr(self, attr_name, func(self))
+
+        # Get the result of the function call that was set in the attr.
+        return getattr(self, attr_name)
+
+    return _lazy_property
+
+
 class Duffel:
     """Client to the entire API"""
 
@@ -25,138 +47,77 @@ class Duffel:
         # instantiating the HttpClient through class inheritance.
         # We should (maybe!) have a singleton pattern on HttpClient and use
         # composition in all of these instead.
+
+        # Keep this as we use it when doing the lazy-evaluation of the different
+        # clients
         self._kwargs = kwargs
 
-        # Lazily initialise clients by when they're called
-        self.aircraft_client = None
-        self.airport_client = None
-        self.airline_client = None
-        self.offer_request_client = None
-        self.offer_client = None
-        self.order_client = None
-        self.order_cancellation_client = None
-        self.order_change_client = None
-        self.order_change_offer_client = None
-        self.order_change_request_client = None
-        self.payment_intent_client = None
-        self.payment_client = None
-        self.seat_map_client = None
-        self.webhook_client = None
-
-    @property
+    @lazy_property
     def aircraft(self):
         """Aircraft API - /air/aircraft"""
-        if isinstance(self.aircraft_client, type(None)):
-            setattr(self, "aircraft_client", AircraftClient(**self._kwargs))
-        return self.aircraft_client
+        return AircraftClient(**self._kwargs)
 
-    @property
+    @lazy_property
     def airports(self):
         """Airports API - /air/airports"""
-        if isinstance(self.airport_client, type(None)):
-            setattr(self, "airport_client", AirportClient(**self._kwargs))
-        return self.airport_client
+        return AirportClient(**self._kwargs)
 
-    @property
+    @lazy_property
     def airlines(self):
         """Airlines API - /air/airlines"""
-        if isinstance(self.airline_client, type(None)):
-            setattr(self, "airline_client", AirlineClient(**self._kwargs))
-        return self.airline_client
+        return AirlineClient(**self._kwargs)
 
-    @property
+    @lazy_property
     def offer_requests(self):
         """Offer Requests API - /air/offer_requests"""
-        if isinstance(self.offer_request_client, type(None)):
-            setattr(
-                self,
-                "offer_request_client",
-                OfferRequestClient(**self._kwargs),
-            )
-        return self.offer_request_client
+        return OfferRequestClient(**self._kwargs)
 
-    @property
+    @lazy_property
     def offers(self):
         """Offers API - /air/offers"""
-        if isinstance(self.offer_client, type(None)):
-            setattr(self, "offer_client", OfferClient(**self._kwargs))
-        return self.offer_client
+        return OfferClient(**self._kwargs)
 
-    @property
+    @lazy_property
     def orders(self):
         """Orders API - /air/orders"""
-        if isinstance(self.order_client, type(None)):
-            setattr(self, "order_client", OrderClient(**self._kwargs))
-        return self.order_client
+        return OrderClient(**self._kwargs)
 
-    @property
+    @lazy_property
     def order_cancellations(self):
         """Order Cancellations API - /air/order_cancellations"""
-        if isinstance(self.order_cancellation_client, type(None)):
-            setattr(
-                self,
-                "order_cancellation_client",
-                OrderCancellationClient(**self._kwargs),
-            )
-        return self.order_cancellation_client
+        return OrderCancellationClient(**self._kwargs)
 
-    @property
+    @lazy_property
     def order_changes(self):
         """Order Changes API - /air/order_changes"""
-        if isinstance(self.order_change_client, type(None)):
-            setattr(
-                self,
-                "order_change_client",
-                OrderChangeClient(**self._kwargs),
-            )
-        return self.order_change_client
+        return OrderChangeClient(**self._kwargs)
 
-    @property
+    @lazy_property
     def order_change_offers(self):
         """Order Change Offers API - /air/order_change_offers"""
-        if isinstance(self.order_change_offer_client, type(None)):
-            setattr(
-                self,
-                "order_change_offer_client",
-                OrderChangeOfferClient(**self._kwargs),
-            )
-        return self.order_change_offer_client
+        return OrderChangeOfferClient(**self._kwargs)
 
-    @property
+    @lazy_property
     def order_change_requests(self):
         """Order Change Requests API - /air/order_change_requests"""
-        if isinstance(self.order_change_request_client, type(None)):
-            setattr(
-                self,
-                "order_change_request_client",
-                OrderChangeRequestClient(**self._kwargs),
-            )
-        return self.order_change_request_client
+        return OrderChangeRequestClient(**self._kwargs)
 
-    @property
+    @lazy_property
     def payment_intents(self):
         """Payment Intents API - /payments/payment_intents"""
-        if isinstance(self.payment_intent_client, type(None)):
-            setattr(self, "payment_intent_client", PaymentIntentClient(**self._kwargs))
-        return self.payment_intent_client
+        return PaymentIntentClient(**self._kwargs)
 
-    @property
+    @lazy_property
     def payments(self):
         """Payments API - /air/payments"""
-        if isinstance(self.payment_client, type(None)):
-            setattr(self, "payment_client", PaymentClient(**self._kwargs))
-        return self.payment_client
+        return PaymentClient(**self._kwargs)
 
-    @property
+    @lazy_property
     def seat_maps(self):
         """Seat Maps API - /air/seat_maps"""
-        if isinstance(self.seat_map_client, type(None)):
-            setattr(self, "seat_map_client", SeatMapClient(**self._kwargs))
-        return self.seat_map_client
+        return SeatMapClient(**self._kwargs)
 
-    @property
+    @lazy_property
     def webhooks(self):
         """Webhooks API - /air/webhooks (Preview)"""
-        if isinstance(self.webhook_client, type(None)):
-            setattr(self, "webhook_client", WebhookClient(**self._kwargs))
-        return self.webhook_client
+        return WebhookClient(**self._kwargs)


### PR DESCRIPTION
We'd see type errors like this:

```
duffelhq/duffel-api-python/tests/test_offers.py:10:31 - error: Cannot access member "get" for type "None"
    Member "get" is unknown (reportGeneralTypeIssues)
```

This PR replaces the incorrectly (or rather, unused) `@property` with our custom `@lazy_property` decorator.

This decorator effectively does the same thing as we were doing in each function client for the different clients.

The type errors are solved as we're no longer setting those properties to `None` at first, which was done to avoid some other type warnings, I believe!

Here's an example:

```
>>> client = Duffel(access_token = "xxxx")
>>> client.__dict__
{'_kwargs': {'access_token': 'xxxx'}}
>>> client.offers.list("offer_request_id")
<duffel_api.http_client.Pagination object at 0x110a2a340>
>>> client.__dict__
{'_kwargs': {'access_token': 'xxxx'}, '_lazy_offers': <duffel_api.api.booking.offers.OfferClient object at 0x11087de50>}
>>> client.offers.list("offer_request_id")
<duffel_api.http_client.Pagination object at 0x110bb4e20>
>>> client.__dict__
{'_kwargs': {'access_token': 'xxxx'}, '_lazy_offers': <duffel_api.api.booking.offers.OfferClient object at 0x11087de50>}
```

You can see that the `Duffel` class doesn't yet have the lazy attribute (`_lazy_offers`) at first (proven through `__dict__`). Subsequent calls add, and re-use, it.