### PR TITLE
[FLAPI-2083] Add type stubs for setuptools

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ commands = black . {posargs}
 deps =
     mypy
     types-requests
+    types-setuptools
 commands = mypy {toxinidir}
 
 [testenv:pyright]


### PR DESCRIPTION
This satisfies:

`setup.py:1: error: Skipping analyzing "setuptools": module is installed, but missing library stubs or py.typed marker`
