### PR TITLE
[FLAPI-2083] Add type stubs for TOML

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ deps =
     mypy
     types-requests
     types-setuptools
+    types-toml
 commands = mypy {toxinidir}
 
 [testenv:pyright]


### PR DESCRIPTION
This was recommended by `mypy --install-types`.
