### PR TITLE
[FLAPI-2083] Add missing dependency for type checking

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,10 +49,13 @@ deps =
     types-requests
     types-setuptools
     types-toml
+    pytest
 commands = mypy {toxinidir}
 
 [testenv:pyright]
-deps = pyright
+deps =
+    pyright
+    pytest
 commands = pyright
 
 [testenv:types]


### PR DESCRIPTION
This satisfies:

```
tests/test_http_client.py:1: error: Cannot find implementation or library stub for module named "pytest"
tests/test_http_client.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
tests/test_payments.py:1: error: Cannot find implementation or library stub for module named "pytest"
tests/test_payment_intents.py:1: error: Cannot find implementation or library stub for module named "pytest"
tests/test_orders.py:2: error: Cannot find implementation or library stub for module named "pytest"
tests/test_order_changes.py:3: error: Cannot find implementation or library stub for module named "pytest"
tests/test_offers.py:1: error: Cannot find implementation or library stub for module named "pytest"
tests/test_offer_requests.py:1: error: Cannot find implementation or library stub for module named "pytest"
```
