### PR TITLE
GitHub Actions: `integration-test` and `types` check jobs required for `publish`

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -100,7 +100,7 @@ jobs:
       with:
         python-version: 3.9
     - name: Install dependencies
-      run: pip install build tox tox-gh-actions
+      run: pip install tox tox-gh-actions
     - name: Check with pyright
       run: tox -e pyright
     - name: Check with mypy

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    needs: [test]
+    needs: [integration-test, test, types]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
💁 These changes make the `integration-test` and `types` jobs required for publishing new package versions.