### PR TITLE
Use f-strings everywhere [FLAPI-2162]

### DIFF
--- a/duffel_api/api/booking/offer_requests.py
+++ b/duffel_api/api/booking/offer_requests.py
@@ -15,9 +15,7 @@ class OfferRequestClient(HttpClient):
 
     def get(self, id_):
         """GET /air/offer_requests/:id"""
-        return OfferRequest.from_json(
-            self.do_get("{}/{}".format(self._url, id_))["data"]
-        )
+        return OfferRequest.from_json(self.do_get(f"{self._url}/{id_}")["data"])
 
     def list(self, limit=50):
         """GET /air/offer_requests"""

--- a/duffel_api/api/booking/offers.py
+++ b/duffel_api/api/booking/offers.py
@@ -70,7 +70,7 @@ class OfferClient(HttpClient):
         if return_available_services:
             params["return_available_services"] = "true"
         return Offer.from_json(
-            self.do_get("{}/{}".format(self._url, id_), query_params=params)["data"]
+            self.do_get(f"{self._url}/{id_}", query_params=params)["data"]
         )
 
     def list(self, offer_request_id, sort=None, max_connections=None, limit=50):

--- a/duffel_api/api/booking/order_cancellations.py
+++ b/duffel_api/api/booking/order_cancellations.py
@@ -20,9 +20,7 @@ class OrderCancellationClient(HttpClient):
 
     def get(self, id_):
         """GET /air/order_cancellations/:id."""
-        return OrderCancellation.from_json(
-            self.do_get("{}/{}".format(self._url, id_))["data"]
-        )
+        return OrderCancellation.from_json(self.do_get(f"{self._url}/{id_}")["data"])
 
     def list(self, order_id, limit=50):
         """Retrieve a paginated list of order cancellations."""
@@ -55,5 +53,5 @@ class OrderCancellationClient(HttpClient):
         your customer (e.g. back to their credit/debit card).
 
         """
-        url = "{}/{}/actions/confirm".format(self._url, id_)
+        url = f"{self._url}/{id_}/actions/confirm"
         return OrderCancellation.from_json(self.do_post(url)["data"])

--- a/duffel_api/api/booking/order_change_offers.py
+++ b/duffel_api/api/booking/order_change_offers.py
@@ -11,9 +11,7 @@ class OrderChangeOfferClient(HttpClient):
 
     def get(self, id_):
         """GET /air/order_change_offers/:id"""
-        return OrderChangeOffer.from_json(
-            self.do_get("{}/{}".format(self._url, id_))["data"]
-        )
+        return OrderChangeOffer.from_json(self.do_get(f"{self._url}/{id_}")["data"])
 
     def list(self, order_change_request_id, sort=None, max_connections=None, limit=50):
         """GET /air/order_change_offers"""

--- a/duffel_api/api/booking/order_change_requests.py
+++ b/duffel_api/api/booking/order_change_requests.py
@@ -16,9 +16,7 @@ class OrderChangeRequestClient(HttpClient):
 
     def get(self, id_):
         """GET /air/order_change_requests/:id"""
-        return OrderChangeRequest.from_json(
-            self.do_get("{}/{}".format(self._url, id_))["data"]
-        )
+        return OrderChangeRequest.from_json(self.do_get(f"{self._url}/{id_}")["data"])
 
 
 class OrderChangeRequestCreate:

--- a/duffel_api/api/booking/order_changes.py
+++ b/duffel_api/api/booking/order_changes.py
@@ -26,9 +26,7 @@ class OrderChangeClient(HttpClient):
 
     def get(self, id_):
         """GET /air/order_changes/:id."""
-        return OrderChange.from_json(
-            self.do_get("{}/{}".format(self._url, id_))["data"]
-        )
+        return OrderChange.from_json(self.do_get(f"{self._url}/{id_}")["data"])
 
     def create(self, selected_order_change_offer):
         """Create a pending order change.
@@ -64,7 +62,7 @@ class OrderChangeClient(HttpClient):
         """
         OrderChangeClient._validate_payment(payment_)
 
-        url = "{}/{}/actions/confirm".format(self._url, id_)
+        url = f"{self._url}/{id_}/actions/confirm"
 
         res = self.do_post(
             url,

--- a/duffel_api/api/booking/orders.py
+++ b/duffel_api/api/booking/orders.py
@@ -15,7 +15,7 @@ class OrderClient(HttpClient):
 
     def get(self, id_):
         """GET /air/orders/:id."""
-        return Order.from_json(self.do_get("{}/{}".format(self._url, id_))["data"])
+        return Order.from_json(self.do_get(f"{self._url}/{id_}")["data"])
 
     def list(self, awaiting_payment=False, sort=None, limit=50):
         """GET /air/orders."""

--- a/duffel_api/api/duffel_payments/payment_intents.py
+++ b/duffel_api/api/duffel_payments/payment_intents.py
@@ -26,9 +26,7 @@ class PaymentIntentClient(HttpClient):
         You should use this API to get the complete, up-to-date information
         about a Payment Intent.
         """
-        return PaymentIntent.from_json(
-            self.do_get("{}/{}".format(self._url, id_))["data"]
-        )
+        return PaymentIntent.from_json(self.do_get(f"{self._url}/{id_}")["data"])
 
     def confirm(self, id_):
         """Confirm a Payment Intent
@@ -40,7 +38,7 @@ class PaymentIntentClient(HttpClient):
         Once confirmed, the amount charged to your customer's card will be added
         to your Balance (minus any Duffel Payment fees).
         """
-        url = "{}/{}/actions/confirm".format(self._url, id_)
+        url = f"{self._url}/{id_}/actions/confirm"
         return PaymentIntent.from_json(self.do_post(url)["data"])
 
 

--- a/duffel_api/api/notifications/webhooks.py
+++ b/duffel_api/api/notifications/webhooks.py
@@ -28,7 +28,7 @@ class WebhookClient(HttpClient):
 
         Send a ping, a "fake event" notification, to a webhook.
         """
-        url = "{}/{}/actions/ping".format(self._url, id_)
+        url = f"{self._url}/{id_}/actions/ping"
         self.do_post(url)
         return None
 
@@ -72,7 +72,7 @@ class WebhookUpdate(object):
 
     def execute(self):
         """PATCH /air/webhooks/{id}"""
-        url = "{}/{}".format(self._client._url, self._id)
+        url = f"{self._client._url}/{self._id}"
 
         res = self._client.do_patch(
             url,

--- a/duffel_api/api/supporting/aircraft.py
+++ b/duffel_api/api/supporting/aircraft.py
@@ -11,7 +11,7 @@ class AircraftClient(HttpClient):
 
     def get(self, id_):
         """GET /air/aircraft/:id"""
-        return Aircraft.from_json(self.do_get("{}/{}".format(self._url, id_))["data"])
+        return Aircraft.from_json(self.do_get(f"{self._url}/{id_}")["data"])
 
     def list(self, limit=50):
         """GET /air/aircraft"""

--- a/duffel_api/api/supporting/airlines.py
+++ b/duffel_api/api/supporting/airlines.py
@@ -11,7 +11,7 @@ class AirlineClient(HttpClient):
 
     def get(self, id_):
         """GET /air/airlines/:id"""
-        return Airline.from_json(self.do_get("{}/{}".format(self._url, id_))["data"])
+        return Airline.from_json(self.do_get(f"{self._url}/{id_}")["data"])
 
     def list(self, limit=50):
         """GET /air/airlines"""

--- a/duffel_api/api/supporting/airports.py
+++ b/duffel_api/api/supporting/airports.py
@@ -11,7 +11,7 @@ class AirportClient(HttpClient):
 
     def get(self, id_):
         """GET /air/airports/:id"""
-        return Airport.from_json(self.do_get("{}/{}".format(self._url, id_))["data"])
+        return Airport.from_json(self.do_get(f"{self._url}/{id_}")["data"])
 
     def list(self, limit=50):
         """GET /air/airports"""

--- a/duffel_api/http_client.py
+++ b/duffel_api/http_client.py
@@ -100,9 +100,7 @@ class HttpClient:
             access_token = os.getenv("DUFFEL_ACCESS_TOKEN")
             if not access_token:
                 raise ClientError("must set DUFFEL_ACCESS_TOKEN")
-        self.http_session.headers.update(
-            {"Authorization": "Bearer {}".format(access_token)}
-        )
+        self.http_session.headers.update({"Authorization": f"Bearer {access_token}"})
 
     def _http_call(self, endpoint, method, query_params=None, body=None):
         """Perform the http call and wrap the response in a ApiError in case an error
@@ -120,18 +118,14 @@ class HttpClient:
             try:
                 return response.json()
             except ValueError as err:
-                raise Exception(
-                    "something bad happened: {}".format(response.text)
-                ) from err
+                raise Exception(f"something bad happened: {response.text}") from err
         elif response.status_code == http_codes.no_content:
             return None
         else:
             try:
                 raise ApiError(response.headers, response.json())
             except ValueError as err:
-                raise Exception(
-                    "something bad happened: {}".format(response.text)
-                ) from err
+                raise Exception(f"something bad happened: {response.text}") from err
             raise response.raise_for_status()
 
     def do_get(self, endpoint, method="GET", query_params=None, body=None):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -14,11 +14,11 @@ def fixture(name, url_path, mock, status_code, with_response=True):
     with open(f"tests/fixtures/{name}.json") as fh:
         if with_response:
             response = json.loads(fh.read())
-            uri = "{}/{}".format(url, url_path)
+            uri = f"{url}/{url_path}"
             mock(uri, complete_qs=True, json=response, status_code=status_code)
             yield Duffel(access_token="some_token", api_url=url)
         else:
-            uri = "{}/{}".format(url, url_path)
+            uri = f"{url}/{url_path}"
             mock(uri, complete_qs=True, status_code=status_code)
             yield Duffel(access_token="some_token", api_url=url)
 


### PR DESCRIPTION
This is a follow-on from previous changes (e.g. https://github.com/duffelhq/duffel-api-python/pull/79).

I used Comby [1] for most of the changes.

[1] `$ comby -i '"{}/{}:[rest]".format(:[arg1], :[arg2])' 'f"{:[arg1]}/{:[arg2]}:[rest]"' .py`
