### PR TITLE
Correct Offer.PaymentRequirements fields being nullable

### DIFF
--- a/duffel_api/models/offer.py
+++ b/duffel_api/models/offer.py
@@ -86,19 +86,23 @@ class OfferConditions:
 class PaymentRequirements:
     """The payment requirements for an offer"""
 
-    payment_required_by: datetime
-    price_guarantee_expires_at: datetime
+    payment_required_by: Optional[datetime]
+    price_guarantee_expires_at: Optional[datetime]
     requires_instant_payment: bool
 
     @classmethod
     def from_json(cls, json: dict):
         """Construct a class instance from a JSON response."""
         return cls(
-            payment_required_by=datetime.strptime(
-                json["payment_required_by"], "%Y-%m-%dT%H:%M:%SZ"
+            payment_required_by=get_and_transform(
+                json,
+                "payment_required_by",
+                lambda value: datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ"),
             ),
-            price_guarantee_expires_at=datetime.strptime(
-                json["price_guarantee_expires_at"], "%Y-%m-%dT%H:%M:%SZ"
+            price_guarantee_expires_at=get_and_transform(
+                json,
+                "price_guarantee_expires_at",
+                lambda value: datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ"),
             ),
             requires_instant_payment=json["requires_instant_payment"],
         )

--- a/tests/fixtures/get-offer-by-id-with-null-payment-requirements.json
+++ b/tests/fixtures/get-offer-by-id-with-null-payment-requirements.json
@@ -1,0 +1,236 @@
+{
+  "data": {
+    "allowed_passenger_identity_document_types": [
+      "passport"
+    ],
+    "available_payment_types": "payments",
+    "available_services": [
+      {
+        "id": "ase_00009UhD4ongolulWd9123",
+        "maximum_quantity": 1,
+        "metadata": {
+          "type": "checked" 
+        },
+        "passenger_ids": [
+          "pas_00009hj8USM7Ncg31cBCLL"
+        ],
+        "segment_ids": [
+          "seg_00009hj8USM7Ncg31cB456"
+        ],
+        "total_amount": "15.00",
+        "total_currency": "GBP",
+        "type": "baggage"
+      }
+    ],
+    "base_amount": "30.20",
+    "base_currency": "GBP",
+    "conditions": {
+      "change_before_departure": {
+        "allowed": true,
+        "penalty_amount": "100.00",
+        "penalty_currency": "GBP"
+      },
+      "refund_before_departure": {
+        "allowed": true,
+        "penalty_amount": "100.00",
+        "penalty_currency": "GBP"
+      }
+    },
+    "created_at": "2020-01-17T10:12:14.545Z",
+    "expires_at": "2020-01-17T10:42:14.545Z",
+    "id": "off_00009htYpSCXrwaB9DnUm0",
+    "live_mode": true,
+    "owner": {
+      "iata_code": "BA",
+      "id": "aln_00001876aqC8c5umZmrRds",
+      "name": "British Airways"
+    },
+    "passenger_identity_documents_required": false,
+    "passengers": [
+      {
+        "age": 14,
+        "id": "pas_00009hj8USM7Ncg31cBCL",
+        "type": "adult"
+      }
+    ],
+    "payment_requirements": {
+      "payment_required_by": null,
+      "price_guarantee_expires_at": null,
+      "requires_instant_payment": false
+    },
+    "slices": [
+      {
+        "conditions": {
+          "change_before_departure": {
+            "allowed": true,
+            "penalty_amount": "100.00",
+            "penalty_currency": "GBP"
+          }
+        },
+        "destination": {
+          "airports": [
+            {
+              "city": {
+                "iata_code": "NYC",
+                "iata_country_code": "US",
+                "id": "cit_nyc_us",
+                "name": "New York"
+              },
+              "city_name": "New York",
+              "iata_code": "JFK",
+              "iata_country_code": "US",
+              "icao_code": "KJFK",
+              "id": "arp_jfk_us",
+              "latitude": 40.640556,
+              "longitude": -73.778519,
+              "name": "John F. Kennedy International Airport",
+              "time_zone": "America/New_York"
+            }
+          ],
+          "city": {
+            "iata_code": "NYC",
+            "iata_country_code": "US",
+            "id": "cit_nyc_us",
+            "name": "New York"
+          },
+          "city_name": "New York",
+          "iata_city_code": "NYC",
+          "iata_code": "JFK",
+          "iata_country_code": "US",
+          "icao_code": "KJFK",
+          "id": "arp_jfk_us",
+          "latitude": 40.640556,
+          "longitude": -73.778519,
+          "name": "John F. Kennedy International Airport",
+          "time_zone": "America/New_York",
+          "type": "airport"
+        },
+        "destination_type": "airport",
+        "duration": "PT02H26M",
+        "fare_brand_name": "Basic",
+        "id": "sli_00009htYpSCXrwaB9Dn123",
+        "origin": {
+          "airports": [
+            {
+              "city": {
+                "iata_code": "LON",
+                "iata_country_code": "GB",
+                "id": "cit_lon_gb",
+                "name": "London"
+              },
+              "city_name": "London",
+              "iata_code": "LHR",
+              "iata_country_code": "GB",
+              "icao_code": "EGLL",
+              "id": "arp_lhr_gb",
+              "latitude": 64.068865,
+              "longitude": -141.951519,
+              "name": "Heathrow",
+              "time_zone": "Europe/London"
+            }
+          ],
+          "city": {
+            "iata_code": "LON",
+            "iata_country_code": "GB",
+            "id": "cit_lon_gb",
+            "name": "London"
+          },
+          "city_name": "London",
+          "iata_city_code": "LON",
+          "iata_code": "LHR",
+          "iata_country_code": "GB",
+          "icao_code": "EGLL",
+          "id": "arp_lhr_gb",
+          "latitude": 64.068865,
+          "longitude": -141.951519,
+          "name": "Heathrow",
+          "time_zone": "Europe/London",
+          "type": "airport"
+        },
+        "origin_type": "airport",
+        "segments": [
+          {
+            "aircraft": {
+              "iata_code": "380",
+              "id": "arc_00009UhD4ongolulWd91Ky",
+              "name": "Airbus Industries A380"
+            },
+            "arriving_at": "2020-06-13T16:38:02",
+            "departing_at": "2020-06-13T16:38:02",
+            "destination": {
+              "city": {
+                "iata_code": "NYC",
+                "iata_country_code": "US",
+                "id": "cit_nyc_us",
+                "name": "New York"
+              },
+              "city_name": "New York",
+              "iata_code": "JFK",
+              "iata_country_code": "US",
+              "icao_code": "KJFK",
+              "id": "arp_jfk_us",
+              "latitude": 40.640556,
+              "longitude": -73.778519,
+              "name": "John F. Kennedy International Airport",
+              "time_zone": "America/New_York"
+            },
+            "destination_terminal": "5",
+            "distance": "424.2",
+            "duration": "PT02H26M",
+            "id": "seg_00009htYpSCXrwaB9Dn456",
+            "marketing_carrier": {
+              "iata_code": "BA",
+              "id": "aln_00001876aqC8c5umZmrRds",
+              "name": "British Airways"
+            },
+            "marketing_carrier_flight_number": "1234",
+            "operating_carrier": {
+              "iata_code": "BA",
+              "id": "aln_00001876aqC8c5umZmrRds",
+              "name": "British Airways"
+            },
+            "operating_carrier_flight_number": "4321",
+            "origin": {
+              "city": {
+                "iata_code": "LON",
+                "iata_country_code": "GB",
+                "id": "cit_lon_gb",
+                "name": "London"
+              },
+              "city_name": "London",
+              "iata_code": "LHR",
+              "iata_country_code": "GB",
+              "icao_code": "EGLL",
+              "id": "arp_lhr_gb",
+              "latitude": 64.068865,
+              "longitude": -141.951519,
+              "name": "Heathrow",
+              "time_zone": "Europe/London"
+            },
+            "origin_terminal": "B",
+            "passengers": [
+              {
+                "baggages": [
+                  {
+                    "quantity": 1,
+                    "type": "checked"
+                  }
+                ],
+                "cabin_class": "economy",
+                "cabin_class_marketing_name": "Economy Basic",
+                "fare_basis_code": "OXZ0RO",
+                "passenger_id": "passenger_0"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "tax_amount": "40.80",
+    "tax_currency": "GBP",
+    "total_amount": "45.00",
+    "total_currency": "GBP",
+    "total_emissions_kg": "460",
+    "updated_at": "2020-01-17T10:12:14.545Z"
+  }
+}

--- a/tests/test_offer.py
+++ b/tests/test_offer.py
@@ -7,3 +7,9 @@ def test_offer_model_parsing():
     name = "get-offer-by-id"
     with raw_fixture(name) as fixture:
         assert Offer.from_json(fixture["data"])
+
+
+def test_offer_model_parsing_with_nullable_payment_requirements():
+    name = "get-offer-by-id-with-null-payment-requirements"
+    with raw_fixture(name) as fixture:
+        assert Offer.from_json(fixture["data"])


### PR DESCRIPTION
Make fields nullable to match our documentation and serialisers.

Going by https://duffel.com/docs/api/offers/schema#offers-schema-payment-requirements, these are nullable. This wasn't caught in our testing as our test fixture has values for these 2 fields.

Fixes #105
