### PR TITLE
feat: Add `content` field to `Order`

### DIFF
--- a/duffel_api/models/order.py
+++ b/duffel_api/models/order.py
@@ -499,6 +499,7 @@ class Order:
     base_currency: Optional[str]
     booking_reference: str
     cancelled_at: Optional[datetime]
+    content: str
     created_at: datetime
     synced_at: Optional[datetime]
     documents: Sequence[OrderDocument]
@@ -528,6 +529,7 @@ class Order:
                 "cancelled_at",
                 lambda value: datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ"),
             ),
+            content=json["content"],
             created_at=datetime.strptime(json["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ"),
             synced_at=get_and_transform(
                 json,

--- a/tests/fixtures/create-hold-order.json
+++ b/tests/fixtures/create-hold-order.json
@@ -4,6 +4,7 @@
     "base_currency": "GBP",
     "booking_reference": "RZPNX8",
     "cancelled_at": "2020-04-11T15:48:11.642Z",
+    "content": "managed",
     "conditions": {
       "change_before_departure": {
         "allowed": true,

--- a/tests/fixtures/create-instant-order.json
+++ b/tests/fixtures/create-instant-order.json
@@ -4,6 +4,7 @@
     "base_currency": "GBP",
     "booking_reference": "RZPNX8",
     "cancelled_at": "2020-04-11T15:48:11.642Z",
+    "content": "managed",
     "conditions": {
       "change_before_departure": {
         "allowed": true,

--- a/tests/fixtures/get-order-by-id.json
+++ b/tests/fixtures/get-order-by-id.json
@@ -4,6 +4,7 @@
     "base_currency": "GBP",
     "booking_reference": "RZPNX8",
     "cancelled_at": "2020-04-11T15:48:11.642Z",
+    "content": "managed",
     "conditions": {
       "change_before_departure": {
         "allowed": true,

--- a/tests/fixtures/get-orders.json
+++ b/tests/fixtures/get-orders.json
@@ -5,6 +5,7 @@
       "base_currency": "GBP",
       "booking_reference": "RZPNX8",
       "cancelled_at": "2020-04-11T15:48:11.642Z",
+      "content": "managed",
       "conditions": {
         "change_before_departure": {
           "allowed": true,

--- a/tests/fixtures/update-order-by-id.json
+++ b/tests/fixtures/update-order-by-id.json
@@ -4,6 +4,7 @@
     "base_currency": "GBP",
     "booking_reference": "RZPNX8",
     "cancelled_at": "2020-04-11T15:48:11.642Z",
+    "content": "managed",
     "conditions": {
       "change_before_departure": {
         "allowed": true,


### PR DESCRIPTION
We've just added this field to our API [1].

[1] https://duffel.com/docs/api/orders/schema#orders-schema-content
