### PR TITLE
feat: Add `available_actions` field to `Order`

### DIFF
--- a/duffel_api/models/order.py
+++ b/duffel_api/models/order.py
@@ -495,6 +495,7 @@ class Order:
 
     id: str
     live_mode: bool
+    available_actions: Sequence[str]
     base_amount: Optional[str]
     base_currency: Optional[str]
     booking_reference: str
@@ -520,6 +521,7 @@ class Order:
         """Construct a class instance from a JSON response."""
         return cls(
             id=json["id"],
+            available_actions=json["available_actions"],
             live_mode=json["live_mode"],
             base_amount=json.get("base_amount"),
             base_currency=json.get("base_currency"),

--- a/tests/fixtures/create-hold-order.json
+++ b/tests/fixtures/create-hold-order.json
@@ -1,5 +1,6 @@
 {
   "data": {
+    "available_actions": ["cancel", "update"],
     "base_amount": "30.20",
     "base_currency": "GBP",
     "booking_reference": "RZPNX8",

--- a/tests/fixtures/create-instant-order.json
+++ b/tests/fixtures/create-instant-order.json
@@ -1,5 +1,6 @@
 {
   "data": {
+    "available_actions": ["cancel", "update"],
     "base_amount": "30.20",
     "base_currency": "GBP",
     "booking_reference": "RZPNX8",

--- a/tests/fixtures/get-order-by-id.json
+++ b/tests/fixtures/get-order-by-id.json
@@ -1,5 +1,6 @@
 {
   "data": {
+    "available_actions": ["cancel", "update"],
     "base_amount": "30.20",
     "base_currency": "GBP",
     "booking_reference": "RZPNX8",

--- a/tests/fixtures/get-orders.json
+++ b/tests/fixtures/get-orders.json
@@ -1,6 +1,7 @@
 {
   "data": [
     {
+      "available_actions": ["cancel", "update"],
       "base_amount": "30.20",
       "base_currency": "GBP",
       "booking_reference": "RZPNX8",

--- a/tests/fixtures/update-order-by-id.json
+++ b/tests/fixtures/update-order-by-id.json
@@ -1,5 +1,6 @@
 {
   "data": {
+    "available_actions": ["cancel", "update"],
     "base_amount": "30.20",
     "base_currency": "GBP",
     "booking_reference": "RZPNX8",


### PR DESCRIPTION
We've just added this field to our API [1].

[1] https://duffel.com/docs/api/orders/schema#orders-schema-available-actions
