### PR TITLE
Add support for multi-step search

### DIFF
--- a/duffel_api/api/__init__.py
+++ b/duffel_api/api/__init__.py
@@ -8,6 +8,10 @@ from .booking.order_cancellations import OrderCancellationClient
 from .booking.order_changes import OrderChangeClient
 from .booking.order_change_offers import OrderChangeOfferClient
 from .booking.order_change_requests import OrderChangeRequestClient
+from .booking.partial_offer_requests import (
+    PartialOfferRequestClient,
+    PartialOfferRequestCreate,
+)
 from .booking.payments import PaymentClient
 from .booking.seat_maps import SeatMapClient
 from .duffel_payments.payment_intents import PaymentIntentClient, PaymentIntentCreate
@@ -27,6 +31,8 @@ __all__ = [
     "OrderCreate",
     "OrderUpdate",
     "OrderCancellationClient",
+    "PartialOfferRequestClient",
+    "PartialOfferRequestCreate",
     "PaymentClient",
     "PaymentIntentClient",
     "PaymentIntentCreate",

--- a/duffel_api/api/booking/partial_offer_requests.py
+++ b/duffel_api/api/booking/partial_offer_requests.py
@@ -1,0 +1,161 @@
+from ...http_client import HttpClient
+from ...models import OfferRequest
+
+
+class PartialOfferRequestClient(HttpClient):
+    """To search for and select flights separately for each slice of the journey, you'll
+    need to create a partial offer reques. A partial offer request describes the
+    passengers and where and when they want to travel (in the form of a list of
+    slices). It may also include additional filters (e.g. a particular cabin to
+    travel in).
+
+    """
+
+    def __init__(self, **kwargs):
+        self._url = "/air/partial_offer_requests"
+        super().__init__(**kwargs)
+
+    def get(self, id_, selected_partial_offer=None):
+        """GET /air/partial_offer_requests/:id
+
+        If a selected_partial_offer is passed:
+        GET /air/partial_offer_requests/:id?selected_partial_offer[]=:selected_partial_offer
+
+
+        Retrieves a partial offers request by its ID, only including partial offers for
+        the current slice of multi-step search flow.
+        """  # noqa: E501
+        response = None
+        if selected_partial_offer is None:
+            response = self.do_get(f"{self._url}/{id_}")
+        else:
+            response = self.do_get(
+                f"{self._url}/{id_}",
+                query_params={"selected_partial_offer[]": selected_partial_offer},
+            )
+
+        if response is not None:
+            return OfferRequest.from_json(response["data"])
+
+    def fares(self, id_, selected_partial_offers=[]):
+        """GET /air/partial_offer_requests/:id/fares
+
+        Retrieves an offer request with offers for fares matching selected partial offers.
+        """
+        response = self.do_get(
+            f"{self._url}/{id_}/fares",
+            query_params={"selected_partial_offer[]": selected_partial_offers},
+        )
+        if response is not None:
+            return OfferRequest.from_json(response["data"])
+
+    def create(self):
+        """Initiate creation of a Partial Offer Request"""
+        return PartialOfferRequestCreate(self)
+
+
+class PartialOfferRequestCreate(object):
+    """Auxiliary class to provide methods for partial offer request creation related data"""  # noqa: E501
+
+    class InvalidCabinClass(Exception):
+        """Invalid cabin class provided"""
+
+    class InvalidNumberOfPassengers(Exception):
+        """Invalid number of passengers provided"""
+
+    class InvalidNumberOfSlices(Exception):
+        """Invalid number of slices provided"""
+
+    class InvalidPassenger(Exception):
+        """Invalid passenger data provided"""
+
+    class InvalidSlice(Exception):
+        """Invalid slice data provided"""
+
+    class InvalidMaxConnectionValue(Exception):
+        """Invalid max connection value provided"""
+
+    def __init__(self, client):
+        self._client = client
+        self._cabin_class = "economy"
+        self._passengers = []
+        self._slices = []
+        self._max_connections = 1
+
+    @staticmethod
+    def _validate_cabin_class(cabin_class):
+        """Validate cabin class"""
+        if cabin_class not in [
+            "first",
+            "business",
+            "economy",
+            "premium_economy",
+        ]:
+            raise PartialOfferRequestCreate.InvalidCabinClass(cabin_class)
+
+    @staticmethod
+    def _validate_passengers(passengers):
+        """Validate passenger count and the data provided for each if any were given"""
+        if len(passengers) == 0:
+            raise PartialOfferRequestCreate.InvalidNumberOfPassengers(passengers)
+        for passenger in passengers:
+            if not ("type" in passenger or "age" in passenger):
+                raise PartialOfferRequestCreate.InvalidPassenger(passenger)
+
+    @staticmethod
+    def _validate_slices(slices):
+        """Validate number of slices and the data provided for each if any were given"""
+        if len(slices) == 0:
+            raise PartialOfferRequestCreate.InvalidNumberOfSlices(slices)
+        for travel_slice in slices:
+            if set(travel_slice.keys()) != set(
+                ["departure_date", "destination", "origin"]
+            ):
+                raise PartialOfferRequestCreate.InvalidSlice(travel_slice)
+
+    @staticmethod
+    def _validate_max_connections(max_connections):
+        """Validate the max connection number"""
+        if not isinstance(max_connections, int) or max_connections < 0:
+            raise PartialOfferRequestCreate.InvalidMaxConnectionValue(max_connections)
+
+    def cabin_class(self, cabin_class):
+        """Set cabin_class - defaults to 'economy'"""
+        PartialOfferRequestCreate._validate_cabin_class(cabin_class)
+        self._cabin_class = cabin_class
+        return self
+
+    def passengers(self, passengers):
+        """Set the passengers that will be travelling"""
+        PartialOfferRequestCreate._validate_passengers(passengers)
+        self._passengers = passengers
+        return self
+
+    def slices(self, slices):
+        """Set the slices for the origin-destination we want to travel"""
+        PartialOfferRequestCreate._validate_slices(slices)
+        self._slices = slices
+        return self
+
+    def max_connections(self, max_connections):
+        """Set the max_connections for the journey we want to travel"""
+        PartialOfferRequestCreate._validate_max_connections(max_connections)
+        self._max_connections = max_connections
+        return self
+
+    def execute(self):
+        """POST /air/partial_offer_requests - trigger the call to create the offer_request"""  # noqa: E501
+        PartialOfferRequestCreate._validate_passengers(self._passengers)
+        PartialOfferRequestCreate._validate_slices(self._slices)
+        res = self._client.do_post(
+            self._client._url,
+            body={
+                "data": {
+                    "cabin_class": self._cabin_class,
+                    "passengers": self._passengers,
+                    "max_connections": self._max_connections,
+                    "slices": self._slices,
+                }
+            },
+        )
+        return OfferRequest.from_json(res["data"])

--- a/duffel_api/client.py
+++ b/duffel_api/client.py
@@ -10,6 +10,7 @@ from .api import (
     OrderClient,
     OrderChangeClient,
     OrderChangeOfferClient,
+    PartialOfferRequestClient,
     PaymentClient,
     PaymentIntentClient,
     SeatMapClient,
@@ -101,6 +102,11 @@ class Duffel:
     def order_change_requests(self):
         """Order Change Requests API - /air/order_change_requests"""
         return OrderChangeRequestClient(**self._kwargs)
+
+    @lazy_property
+    def partial_offer_requests(self):
+        """Partial Offer Requests API - /air/partial_offer_requests"""
+        return PartialOfferRequestClient(**self._kwargs)
 
     @lazy_property
     def payment_intents(self):

--- a/duffel_api/models/offer.py
+++ b/duffel_api/models/offer.py
@@ -439,6 +439,7 @@ class Offer:
     updated_at: datetime
     expires_at: datetime
     owner: Airline
+    partial: bool
     passenger_identity_documents_required: bool
     passengers: Sequence[OfferPassenger]
     payment_requirements: PaymentRequirements
@@ -471,6 +472,7 @@ class Offer:
             updated_at=datetime.strptime(json["updated_at"], "%Y-%m-%dT%H:%M:%S.%fZ"),
             expires_at=parse_datetime(json["expires_at"]),
             owner=Airline.from_json(json["owner"]),
+            partial=json["partial"],
             passenger_identity_documents_required=json[
                 "passenger_identity_documents_required"
             ],

--- a/examples/handling-error.py
+++ b/examples/handling-error.py
@@ -1,0 +1,39 @@
+from datetime import date
+import os
+
+from duffel_api import Duffel
+from duffel_api.http_client import ApiError
+
+
+if __name__ == "__main__":
+    print("Duffel Flights API - Python Example on handling errors")
+
+    os.environ["DUFFEL_ACCESS_TOKEN"] = "some-invalid-token-to-trigger-an-error"
+
+    client = Duffel()
+    departure_date = date.today().replace(date.today().year + 1)
+    slices = [
+        {
+            "origin": "LHR",
+            "destination": "STN",
+            "departure_date": departure_date.strftime("%Y-%m-%d"),
+        },
+    ]
+    try:
+        offer_request = (
+            client.offer_requests.create()
+            .passengers(
+                [{"type": "adult"}, {"age": 1}, {"age": (date.today().year - 2003)}]
+            )
+            .slices(slices)
+            .execute()
+        )
+    except ApiError as exc:
+        # This is super useful when contacting Duffel support
+        print(f"Request ID: {exc.meta['request_id']}")
+        print(f"Status Code: {exc.meta['status']}")
+        print("Errors: ")
+        for error in exc.errors:
+            print(f" Title: {error['title']}")
+            print(f" Code: {error['code']}")
+            print(f" Message: {error['message']}")

--- a/examples/multi-step-search-book-one-way-trip.py
+++ b/examples/multi-step-search-book-one-way-trip.py
@@ -5,10 +5,12 @@ from duffel_api import Duffel
 
 
 if __name__ == "__main__":
-    print("Duffel Flights API - search, book and cancel example")
+    print(
+        "Duffel Flights API - search, book and cancel example for multi-step search - one way"
+    )
+
     client = Duffel()
     departure_date = (date.today() + timedelta(weeks=2)).strftime("%Y-%m-%d")
-    departure_date_2 = (date.today() + timedelta(weeks=4)).strftime("%Y-%m-%d")
     slices = [
         {
             "origin": "LHR",

--- a/examples/multi-step-search-book-one-way-trip.py
+++ b/examples/multi-step-search-book-one-way-trip.py
@@ -1,0 +1,105 @@
+from datetime import date, timedelta
+from decimal import Decimal
+
+from duffel_api import Duffel
+
+
+if __name__ == "__main__":
+    print("Duffel Flights API - search, book and cancel example")
+    client = Duffel()
+    departure_date = (date.today() + timedelta(weeks=2)).strftime("%Y-%m-%d")
+    departure_date_2 = (date.today() + timedelta(weeks=4)).strftime("%Y-%m-%d")
+    slices = [
+        {
+            "origin": "LHR",
+            "destination": "STN",
+            "departure_date": departure_date,
+        },
+    ]
+
+    partial_offer_request = (
+        client.partial_offer_requests.create()
+        .passengers([{"type": "adult"}])
+        .slices(slices)
+        .execute()
+    )
+
+    print(f"Created partial offer request: {partial_offer_request.id}")
+
+    offers_list = list(enumerate(partial_offer_request.offers))
+    print(f"Got {len(offers_list)} outbound offers")
+    outbound_partial_offer_id = offers_list[0][1].id
+    print(f"Selected offer {outbound_partial_offer_id} to search for inbound")
+
+    fares_offer_request = client.partial_offer_requests.fares(
+        partial_offer_request.id, [outbound_partial_offer_id]
+    )
+    offers_list = list(enumerate(fares_offer_request.offers))
+    print(f"Got {len(offers_list)} full offers")
+    selected_offer = offers_list[0][1]
+
+    priced_offer = client.offers.get(selected_offer.id, return_available_services=True)
+
+    print(
+        f"The final price for offer {priced_offer.id} is {priced_offer.total_amount} ({priced_offer.total_currency})"
+    )
+
+    available_service = priced_offer.available_services[0]
+
+    print(
+        f"Adding an extra bag with service {available_service.id}, costing {available_service.total_amount} ({available_service.total_currency})"
+    )
+
+    total_amount = str(
+        Decimal(priced_offer.total_amount) + Decimal(available_service.total_amount)
+    )
+    payments = [
+        {
+            "currency": selected_offer.total_currency,
+            "amount": total_amount,
+            "type": "balance",
+        }
+    ]
+    services = [
+        {
+            "id": available_service.id,
+            "quantity": 1,
+        }
+    ]
+    passengers = [
+        {
+            "born_on": "1976-01-21",
+            "email": "conelia.corde@duffel.com",
+            "family_name": "Corde",
+            "gender": "f",
+            "given_name": "Conelia",
+            "id": partial_offer_request.passengers[0].id,
+            "phone_number": "+442080160508",
+            "title": "ms",
+        }
+    ]
+
+    print(total_amount)
+    print(payments)
+    print(services)
+    print(passengers)
+    order = (
+        client.orders.create()
+        .payments(payments)
+        .passengers(passengers)
+        .selected_offers([selected_offer.id])
+        .services(services)
+        .execute()
+    )
+
+    print(f"Created order {order.id} with booking reference {order.booking_reference}")
+
+    order_cancellation = client.order_cancellations.create(order.id)
+
+    print(
+        f"Requested refund quote for order {order.id} – {order_cancellation.refund_amount} ({order_cancellation.refund_currency}) is available"
+    )
+
+    client.order_cancellations.confirm(order_cancellation.id)
+
+    print(f"Confirmed refund quote for order {order.id}")

--- a/examples/multi-step-search-book-return-trip.py
+++ b/examples/multi-step-search-book-return-trip.py
@@ -5,7 +5,9 @@ from duffel_api import Duffel
 
 
 if __name__ == "__main__":
-    print("Duffel Flights API - search, book and cancel example")
+    print(
+        "Duffel Flights API - search, book and cancel example for multi-step search - return trip"
+    )
     client = Duffel()
     departure_date = (date.today() + timedelta(weeks=2)).strftime("%Y-%m-%d")
     departure_date_2 = (date.today() + timedelta(weeks=4)).strftime("%Y-%m-%d")

--- a/examples/multi-step-search-book-return-trip.py
+++ b/examples/multi-step-search-book-return-trip.py
@@ -1,0 +1,118 @@
+from datetime import date, timedelta
+from decimal import Decimal
+
+from duffel_api import Duffel
+
+
+if __name__ == "__main__":
+    print("Duffel Flights API - search, book and cancel example")
+    client = Duffel()
+    departure_date = (date.today() + timedelta(weeks=2)).strftime("%Y-%m-%d")
+    departure_date_2 = (date.today() + timedelta(weeks=4)).strftime("%Y-%m-%d")
+    slices = [
+        {
+            "origin": "LHR",
+            "destination": "STN",
+            "departure_date": departure_date,
+        },
+        {
+            "origin": "STN",
+            "destination": "LHR",
+            "departure_date": departure_date_2,
+        },
+    ]
+
+    partial_offer_request = (
+        client.partial_offer_requests.create()
+        .passengers([{"type": "adult"}])
+        .slices(slices)
+        .execute()
+    )
+
+    print(f"Created partial offer request: {partial_offer_request.id}")
+
+    offers_list = list(enumerate(partial_offer_request.offers))
+    print(f"Got {len(offers_list)} outbound offers")
+    outbound_partial_offer_id = offers_list[0][1].id
+    print(f"Selected offer {outbound_partial_offer_id} to search for inbound")
+
+    inbound_offer_request = client.partial_offer_requests.get(
+        partial_offer_request.id, outbound_partial_offer_id
+    )
+    offers_list = list(enumerate(inbound_offer_request.offers))
+    print(f"Got {len(offers_list)} inbound offers")
+    inbound_partial_offer_id = offers_list[0][1].id
+    print(f"Selected offer {inbound_partial_offer_id} to search for fares")
+
+    fares_offer_request = client.partial_offer_requests.fares(
+        partial_offer_request.id, [outbound_partial_offer_id, inbound_partial_offer_id]
+    )
+    offers_list = list(enumerate(fares_offer_request.offers))
+    print(f"Got {len(offers_list)} full offers")
+    selected_offer = offers_list[0][1]
+
+    priced_offer = client.offers.get(selected_offer.id, return_available_services=True)
+
+    print(
+        f"The final price for offer {priced_offer.id} is {priced_offer.total_amount} ({priced_offer.total_currency})"
+    )
+
+    available_service = priced_offer.available_services[0]
+
+    print(
+        f"Adding an extra bag with service {available_service.id}, costing {available_service.total_amount} ({available_service.total_currency})"
+    )
+
+    total_amount = str(
+        Decimal(priced_offer.total_amount) + Decimal(available_service.total_amount)
+    )
+    payments = [
+        {
+            "currency": selected_offer.total_currency,
+            "amount": total_amount,
+            "type": "balance",
+        }
+    ]
+    services = [
+        {
+            "id": available_service.id,
+            "quantity": 1,
+        }
+    ]
+    passengers = [
+        {
+            "born_on": "1976-01-21",
+            "email": "conelia.corde@duffel.com",
+            "family_name": "Corde",
+            "gender": "f",
+            "given_name": "Conelia",
+            "id": partial_offer_request.passengers[0].id,
+            "phone_number": "+442080160508",
+            "title": "ms",
+        }
+    ]
+
+    print(total_amount)
+    print(payments)
+    print(services)
+    print(passengers)
+    order = (
+        client.orders.create()
+        .payments(payments)
+        .passengers(passengers)
+        .selected_offers([selected_offer.id])
+        .services(services)
+        .execute()
+    )
+
+    print(f"Created order {order.id} with booking reference {order.booking_reference}")
+
+    order_cancellation = client.order_cancellations.create(order.id)
+
+    print(
+        f"Requested refund quote for order {order.id} – {order_cancellation.refund_amount} ({order_cancellation.refund_currency}) is available"
+    )
+
+    client.order_cancellations.confirm(order_cancellation.id)
+
+    print(f"Confirmed refund quote for order {order.id}")

--- a/tests/fixtures/create-partial-offer-request.json
+++ b/tests/fixtures/create-partial-offer-request.json
@@ -3,30 +3,11 @@
     "cabin_class": "economy",
     "created_at": "2020-02-12T15:21:01.927Z",
     "id": "orq_00009hjdomFOCJyxHG7k7k",
-    "live_mode": true,
+    "live_mode": false,
     "offers": [
       {
         "allowed_passenger_identity_document_types": [
           "passport"
-        ],
-        "available_payment_types": "payments",
-        "available_services": [
-          {
-            "id": "ase_00009UhD4ongolulWd9123",
-            "maximum_quantity": 1,
-            "metadata": {
-              "type": "checked"
-            },
-            "passenger_ids": [
-              "pas_00009hj8USM7Ncg31cBCLL"
-            ],
-            "segment_ids": [
-              "seg_00009hj8USM7Ncg31cB456"
-            ],
-            "total_amount": "15.00",
-            "total_currency": "GBP",
-            "type": "baggage"
-          }
         ],
         "base_amount": "30.20",
         "base_currency": "GBP",
@@ -47,16 +28,27 @@
         "id": "off_00009htYpSCXrwaB9DnUm0",
         "live_mode": true,
         "owner": {
+          "conditions_of_carriage_url": "https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage",
           "iata_code": "BA",
           "id": "aln_00001876aqC8c5umZmrRds",
+          "logo_lockup_url": "https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg",
+          "logo_symbol_url": "https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg",
           "name": "British Airways"
         },
-        "partial": false,
+        "partial": true,
         "passenger_identity_documents_required": false,
         "passengers": [
           {
             "age": 14,
+            "family_name": "Earhart",
+            "given_name": "Amelia",
             "id": "pas_00009hj8USM7Ncg31cBCL",
+            "loyalty_programme_accounts": [
+              {
+                "account_number": "12901014",
+                "airline_iata_code": "BA"
+              }
+            ],
             "type": "adult"
           }
         ],
@@ -65,6 +57,13 @@
           "price_guarantee_expires_at": "2020-01-17T10:42:14Z",
           "requires_instant_payment": false
         },
+        "private_fares": [
+          {
+            "corporate_code": "FLX53",
+            "tracking_reference": "ABN:2345678",
+            "type": "corporate"
+          }
+        ],
         "slices": [
           {
             "conditions": {
@@ -78,38 +77,39 @@
               "airports": [
                 {
                   "city": {
-                    "iata_code": "NYC",
-                    "iata_country_code": "US",
-                    "id": "cit_nyc_us",
-                    "name": "New York"
+                    "iata_code": "LON",
+                    "iata_country_code": "GB",
+                    "id": "cit_lon_gb",
+                    "name": "London"
                   },
-                  "city_name": "New York",
-                  "iata_code": "JFK",
-                  "iata_country_code": "US",
-                  "icao_code": "KJFK",
-                  "id": "arp_jfk_us",
-                  "latitude": 40.640556,
-                  "longitude": -73.778519,
-                  "name": "John F. Kennedy International Airport",
-                  "time_zone": "America/New_York"
+                  "city_name": "London",
+                  "iata_city_code": "LON",
+                  "iata_code": "LHR",
+                  "iata_country_code": "GB",
+                  "icao_code": "EGLL",
+                  "id": "arp_lhr_gb",
+                  "latitude": 64.068865,
+                  "longitude": -141.951519,
+                  "name": "Heathrow",
+                  "time_zone": "Europe/London"
                 }
               ],
               "city": {
-                "iata_code": "NYC",
-                "iata_country_code": "US",
-                "id": "cit_nyc_us",
-                "name": "New York"
+                "iata_code": "LON",
+                "iata_country_code": "GB",
+                "id": "cit_lon_gb",
+                "name": "London"
               },
-              "city_name": "New York",
-              "iata_city_code": "NYC",
-              "iata_code": "JFK",
-              "iata_country_code": "US",
-              "icao_code": "KJFK",
-              "id": "arp_jfk_us",
-              "latitude": 40.640556,
-              "longitude": -73.778519,
-              "name": "John F. Kennedy International Airport",
-              "time_zone": "America/New_York",
+              "city_name": "London",
+              "iata_city_code": "LON",
+              "iata_code": "LHR",
+              "iata_country_code": "GB",
+              "icao_code": "EGLL",
+              "id": "arp_lhr_gb",
+              "latitude": 64.068865,
+              "longitude": -141.951519,
+              "name": "Heathrow",
+              "time_zone": "Europe/London",
               "type": "airport"
             },
             "destination_type": "airport",
@@ -126,6 +126,7 @@
                     "name": "London"
                   },
                   "city_name": "London",
+                  "iata_city_code": "LON",
                   "iata_code": "LHR",
                   "iata_country_code": "GB",
                   "icao_code": "EGLL",
@@ -172,6 +173,7 @@
                     "name": "New York"
                   },
                   "city_name": "New York",
+                  "iata_city_code": "NYC",
                   "iata_code": "JFK",
                   "iata_country_code": "US",
                   "icao_code": "KJFK",
@@ -186,14 +188,20 @@
                 "duration": "PT02H26M",
                 "id": "seg_00009htYpSCXrwaB9Dn456",
                 "marketing_carrier": {
+                  "conditions_of_carriage_url": "https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage",
                   "iata_code": "BA",
                   "id": "aln_00001876aqC8c5umZmrRds",
+                  "logo_lockup_url": "https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg",
+                  "logo_symbol_url": "https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg",
                   "name": "British Airways"
                 },
                 "marketing_carrier_flight_number": "1234",
                 "operating_carrier": {
+                  "conditions_of_carriage_url": "https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage",
                   "iata_code": "BA",
                   "id": "aln_00001876aqC8c5umZmrRds",
+                  "logo_lockup_url": "https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg",
+                  "logo_symbol_url": "https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg",
                   "name": "British Airways"
                 },
                 "operating_carrier_flight_number": "4321",
@@ -205,6 +213,7 @@
                     "name": "London"
                   },
                   "city_name": "London",
+                  "iata_city_code": "LON",
                   "iata_code": "LHR",
                   "iata_country_code": "GB",
                   "icao_code": "EGLL",
@@ -228,6 +237,52 @@
                     "fare_basis_code": "OXZ0RO",
                     "passenger_id": "passenger_0"
                   }
+                ],
+                "stops": [
+                  {
+                    "airport": {
+                      "airports": [
+                        {
+                          "city": {
+                            "iata_code": "LON",
+                            "iata_country_code": "GB",
+                            "id": "cit_lon_gb",
+                            "name": "London"
+                          },
+                          "city_name": "London",
+                          "iata_city_code": "LON",
+                          "iata_code": "LHR",
+                          "iata_country_code": "GB",
+                          "icao_code": "EGLL",
+                          "id": "arp_lhr_gb",
+                          "latitude": 64.068865,
+                          "longitude": -141.951519,
+                          "name": "Heathrow",
+                          "time_zone": "Europe/London"
+                        }
+                      ],
+                      "city": {
+                        "iata_code": "LON",
+                        "iata_country_code": "GB",
+                        "id": "cit_lon_gb",
+                        "name": "London"
+                      },
+                      "city_name": "London",
+                      "iata_city_code": "LON",
+                      "iata_code": "LHR",
+                      "iata_country_code": "GB",
+                      "icao_code": "EGLL",
+                      "id": "arp_lhr_gb",
+                      "latitude": 64.068865,
+                      "longitude": -141.951519,
+                      "name": "Heathrow",
+                      "time_zone": "Europe/London",
+                      "type": "airport"
+                    },
+                    "departing_at": "2020-06-13T16:38:02",
+                    "duration": "PT02H26M",
+                    "id": "sto_00009htYpSCXrwaB9Dn456"
+                  }
                 ]
               }
             ]
@@ -238,7 +293,7 @@
         "total_amount": "45.00",
         "total_currency": "GBP",
         "total_emissions_kg": "460",
-        "updated_at": "2020-01-17T10:12:14.545Z"
+        "updated_at": "2020-01-17T10:42:14.545Z"
       }
     ],
     "passengers": [
@@ -263,38 +318,39 @@
           "airports": [
             {
               "city": {
-                "iata_code": "NYC",
-                "iata_country_code": "US",
-                "id": "cit_nyc_us",
-                "name": "New York"
+                "iata_code": "LON",
+                "iata_country_code": "GB",
+                "id": "cit_lon_gb",
+                "name": "London"
               },
-              "city_name": "New York",
-              "iata_code": "JFK",
-              "iata_country_code": "US",
-              "icao_code": "KJFK",
-              "id": "arp_jfk_us",
-              "latitude": 40.640556,
-              "longitude": -73.778519,
-              "name": "John F. Kennedy International Airport",
-              "time_zone": "America/New_York"
+              "city_name": "London",
+              "iata_city_code": "LON",
+              "iata_code": "LHR",
+              "iata_country_code": "GB",
+              "icao_code": "EGLL",
+              "id": "arp_lhr_gb",
+              "latitude": 64.068865,
+              "longitude": -141.951519,
+              "name": "Heathrow",
+              "time_zone": "Europe/London"
             }
           ],
           "city": {
-            "iata_code": "NYC",
-            "iata_country_code": "US",
-            "id": "cit_nyc_us",
-            "name": "New York"
+            "iata_code": "LON",
+            "iata_country_code": "GB",
+            "id": "cit_lon_gb",
+            "name": "London"
           },
-          "city_name": "New York",
-          "iata_city_code": "NYC",
-          "iata_code": "JFK",
-          "iata_country_code": "US",
-          "icao_code": "KJFK",
-          "id": "arp_jfk_us",
-          "latitude": 40.640556,
-          "longitude": -73.778519,
-          "name": "John F. Kennedy International Airport",
-          "time_zone": "America/New_York",
+          "city_name": "London",
+          "iata_city_code": "LON",
+          "iata_code": "LHR",
+          "iata_country_code": "GB",
+          "icao_code": "EGLL",
+          "id": "arp_lhr_gb",
+          "latitude": 64.068865,
+          "longitude": -141.951519,
+          "name": "Heathrow",
+          "time_zone": "Europe/London",
           "type": "airport"
         },
         "destination_type": "airport",
@@ -308,6 +364,7 @@
                 "name": "London"
               },
               "city_name": "London",
+              "iata_city_code": "LON",
               "iata_code": "LHR",
               "iata_country_code": "GB",
               "icao_code": "EGLL",

--- a/tests/fixtures/get-offer-by-id-with-null-payment-requirements.json
+++ b/tests/fixtures/get-offer-by-id-with-null-payment-requirements.json
@@ -9,7 +9,7 @@
         "id": "ase_00009UhD4ongolulWd9123",
         "maximum_quantity": 1,
         "metadata": {
-          "type": "checked" 
+          "type": "checked"
         },
         "passenger_ids": [
           "pas_00009hj8USM7Ncg31cBCLL"
@@ -45,6 +45,7 @@
       "id": "aln_00001876aqC8c5umZmrRds",
       "name": "British Airways"
     },
+    "partial": false,
     "passenger_identity_documents_required": false,
     "passengers": [
       {

--- a/tests/fixtures/get-offer-by-id.json
+++ b/tests/fixtures/get-offer-by-id.json
@@ -45,6 +45,7 @@
       "id": "aln_00001876aqC8c5umZmrRds",
       "name": "British Airways"
     },
+    "partial": false,
     "passenger_identity_documents_required": false,
     "passengers": [
       {

--- a/tests/fixtures/get-offers.json
+++ b/tests/fixtures/get-offers.json
@@ -27,6 +27,7 @@
         "id": "aln_00001876aqC8c5umZmrRds",
         "name": "British Airways"
       },
+      "partial": false,
       "passenger_identity_documents_required": false,
       "passengers": [
         {

--- a/tests/fixtures/get-partial-offer-request-by-id.json
+++ b/tests/fixtures/get-partial-offer-request-by-id.json
@@ -3,30 +3,11 @@
     "cabin_class": "economy",
     "created_at": "2020-02-12T15:21:01.927Z",
     "id": "orq_00009hjdomFOCJyxHG7k7k",
-    "live_mode": true,
+    "live_mode": false,
     "offers": [
       {
         "allowed_passenger_identity_document_types": [
           "passport"
-        ],
-        "available_payment_types": "payments",
-        "available_services": [
-          {
-            "id": "ase_00009UhD4ongolulWd9123",
-            "maximum_quantity": 1,
-            "metadata": {
-              "type": "checked"
-            },
-            "passenger_ids": [
-              "pas_00009hj8USM7Ncg31cBCLL"
-            ],
-            "segment_ids": [
-              "seg_00009hj8USM7Ncg31cB456"
-            ],
-            "total_amount": "15.00",
-            "total_currency": "GBP",
-            "type": "baggage"
-          }
         ],
         "base_amount": "30.20",
         "base_currency": "GBP",
@@ -47,16 +28,27 @@
         "id": "off_00009htYpSCXrwaB9DnUm0",
         "live_mode": true,
         "owner": {
+          "conditions_of_carriage_url": "https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage",
           "iata_code": "BA",
           "id": "aln_00001876aqC8c5umZmrRds",
+          "logo_locku_purl": "https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg",
+          "logo_symbol_url": "https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg",
           "name": "British Airways"
         },
-        "partial": false,
+        "partial": true,
         "passenger_identity_documents_required": false,
         "passengers": [
           {
             "age": 14,
+            "family_name": "Earhart",
+            "given_name": "Amelia",
             "id": "pas_00009hj8USM7Ncg31cBCL",
+            "loyalty_programme_accounts": [
+              {
+                "account_number": "12901014",
+                "airline_iata_code": "BA"
+              }
+            ],
             "type": "adult"
           }
         ],
@@ -65,6 +57,13 @@
           "price_guarantee_expires_at": "2020-01-17T10:42:14Z",
           "requires_instant_payment": false
         },
+        "private_fares": [
+          {
+            "corporate_code": "FLX53",
+            "tracking_reference": "ABN:2345678",
+            "type": "corporate"
+          }
+        ],
         "slices": [
           {
             "conditions": {
@@ -78,38 +77,39 @@
               "airports": [
                 {
                   "city": {
-                    "iata_code": "NYC",
-                    "iata_country_code": "US",
-                    "id": "cit_nyc_us",
-                    "name": "New York"
+                    "iata_code": "LON",
+                    "iata_country_code": "GB",
+                    "id": "cit_lon_gb",
+                    "name": "London"
                   },
-                  "city_name": "New York",
-                  "iata_code": "JFK",
-                  "iata_country_code": "US",
-                  "icao_code": "KJFK",
-                  "id": "arp_jfk_us",
-                  "latitude": 40.640556,
-                  "longitude": -73.778519,
-                  "name": "John F. Kennedy International Airport",
-                  "time_zone": "America/New_York"
+                  "city_name": "London",
+                  "iata_city_code": "LON",
+                  "iata_code": "LHR",
+                  "iata_country_code": "GB",
+                  "icao_code": "EGLL",
+                  "id": "arp_lhr_gb",
+                  "latitude": 64.068865,
+                  "longitude": -141.951519,
+                  "name": "Heathrow",
+                  "time_zone": "Europe/London"
                 }
               ],
               "city": {
-                "iata_code": "NYC",
-                "iata_country_code": "US",
-                "id": "cit_nyc_us",
-                "name": "New York"
+                "iata_code": "LON",
+                "iata_country_code": "GB",
+                "id": "cit_lon_gb",
+                "name": "London"
               },
-              "city_name": "New York",
-              "iata_city_code": "NYC",
-              "iata_code": "JFK",
-              "iata_country_code": "US",
-              "icao_code": "KJFK",
-              "id": "arp_jfk_us",
-              "latitude": 40.640556,
-              "longitude": -73.778519,
-              "name": "John F. Kennedy International Airport",
-              "time_zone": "America/New_York",
+              "city_name": "London",
+              "iata_city_code": "LON",
+              "iata_code": "LHR",
+              "iata_country_code": "GB",
+              "icao_code": "EGLL",
+              "id": "arp_lhr_gb",
+              "latitude": 64.068865,
+              "longitude": -141.951519,
+              "name": "Heathrow",
+              "time_zone": "Europe/London",
               "type": "airport"
             },
             "destination_type": "airport",
@@ -126,6 +126,7 @@
                     "name": "London"
                   },
                   "city_name": "London",
+                  "iata_city_code": "LON",
                   "iata_code": "LHR",
                   "iata_country_code": "GB",
                   "icao_code": "EGLL",
@@ -172,6 +173,7 @@
                     "name": "New York"
                   },
                   "city_name": "New York",
+                  "iata_city_code": "NYC",
                   "iata_code": "JFK",
                   "iata_country_code": "US",
                   "icao_code": "KJFK",
@@ -186,14 +188,20 @@
                 "duration": "PT02H26M",
                 "id": "seg_00009htYpSCXrwaB9Dn456",
                 "marketing_carrier": {
+                  "conditions_of_carriage_url": "https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage",
                   "iata_code": "BA",
                   "id": "aln_00001876aqC8c5umZmrRds",
+                  "logo_lockup_url": "https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg",
+                  "logo_symbol_url": "https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg",
                   "name": "British Airways"
                 },
                 "marketing_carrier_flight_number": "1234",
                 "operating_carrier": {
+                  "conditions_of_carriage_url": "https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage",
                   "iata_code": "BA",
                   "id": "aln_00001876aqC8c5umZmrRds",
+                  "logo_lockup_url": "https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg",
+                  "logo_symbol_url": "https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg",
                   "name": "British Airways"
                 },
                 "operating_carrier_flight_number": "4321",
@@ -205,6 +213,7 @@
                     "name": "London"
                   },
                   "city_name": "London",
+                  "iata_city_code": "LON",
                   "iata_code": "LHR",
                   "iata_country_code": "GB",
                   "icao_code": "EGLL",
@@ -228,6 +237,52 @@
                     "fare_basis_code": "OXZ0RO",
                     "passenger_id": "passenger_0"
                   }
+                ],
+                "stops": [
+                  {
+                    "airport": {
+                      "airports": [
+                        {
+                          "city": {
+                            "iata_code": "LON",
+                            "iata_country_code": "GB",
+                            "id": "cit_lon_gb",
+                            "name": "London"
+                          },
+                          "city_name": "London",
+                          "iata_city_code": "LON",
+                          "iata_code": "LHR",
+                          "iata_country_code": "GB",
+                          "icao_code": "EGLL",
+                          "id": "arp_lhr_gb",
+                          "latitude": 64.068865,
+                          "longitude": -141.951519,
+                          "name": "Heathrow",
+                          "time_zone": "Europe/London"
+                        }
+                      ],
+                      "city": {
+                        "iata_code": "LON",
+                        "iata_country_code": "GB",
+                        "id": "cit_lon_gb",
+                        "name": "London"
+                      },
+                      "city_name": "London",
+                      "iata_city_code": "LON",
+                      "iata_code": "LHR",
+                      "iata_country_code": "GB",
+                      "icao_code": "EGLL",
+                      "id": "arp_lhr_gb",
+                      "latitude": 64.068865,
+                      "longitude": -141.951519,
+                      "name": "Heathrow",
+                      "time_zone": "Europe/London",
+                      "type": "airport"
+                    },
+                    "departing_at": "2020-06-13T16:38:02",
+                    "duration": "PT02H26M",
+                    "id": "sto_00009htYpSCXrwaB9Dn456"
+                  }
                 ]
               }
             ]
@@ -238,7 +293,7 @@
         "total_amount": "45.00",
         "total_currency": "GBP",
         "total_emissions_kg": "460",
-        "updated_at": "2020-01-17T10:12:14.545Z"
+        "updated_at": "2020-01-17T10:42:14.545Z"
       }
     ],
     "passengers": [
@@ -263,38 +318,39 @@
           "airports": [
             {
               "city": {
-                "iata_code": "NYC",
-                "iata_country_code": "US",
-                "id": "cit_nyc_us",
-                "name": "New York"
+                "iata_code": "LON",
+                "iata_country_code": "GB",
+                "id": "cit_lon_gb",
+                "name": "London"
               },
-              "city_name": "New York",
-              "iata_code": "JFK",
-              "iata_country_code": "US",
-              "icao_code": "KJFK",
-              "id": "arp_jfk_us",
-              "latitude": 40.640556,
-              "longitude": -73.778519,
-              "name": "John F. Kennedy International Airport",
-              "time_zone": "America/New_York"
+              "city_name": "London",
+              "iata_city_code": "LON",
+              "iata_code": "LHR",
+              "iata_country_code": "GB",
+              "icao_code": "EGLL",
+              "id": "arp_lhr_gb",
+              "latitude": 64.068865,
+              "longitude": -141.951519,
+              "name": "Heathrow",
+              "time_zone": "Europe/London"
             }
           ],
           "city": {
-            "iata_code": "NYC",
-            "iata_country_code": "US",
-            "id": "cit_nyc_us",
-            "name": "New York"
+            "iata_code": "LON",
+            "iata_country_code": "GB",
+            "id": "cit_lon_gb",
+            "name": "London"
           },
-          "city_name": "New York",
-          "iata_city_code": "NYC",
-          "iata_code": "JFK",
-          "iata_country_code": "US",
-          "icao_code": "KJFK",
-          "id": "arp_jfk_us",
-          "latitude": 40.640556,
-          "longitude": -73.778519,
-          "name": "John F. Kennedy International Airport",
-          "time_zone": "America/New_York",
+          "city_name": "London",
+          "iata_city_code": "LON",
+          "iata_code": "LHR",
+          "iata_country_code": "GB",
+          "icao_code": "EGLL",
+          "id": "arp_lhr_gb",
+          "latitude": 64.068865,
+          "longitude": -141.951519,
+          "name": "Heathrow",
+          "time_zone": "Europe/London",
           "type": "airport"
         },
         "destination_type": "airport",
@@ -308,6 +364,7 @@
                 "name": "London"
               },
               "city_name": "London",
+              "iata_city_code": "LON",
               "iata_code": "LHR",
               "iata_country_code": "GB",
               "icao_code": "EGLL",

--- a/tests/fixtures/get-partial-offer-request-fares-by-id.json
+++ b/tests/fixtures/get-partial-offer-request-fares-by-id.json
@@ -3,30 +3,11 @@
     "cabin_class": "economy",
     "created_at": "2020-02-12T15:21:01.927Z",
     "id": "orq_00009hjdomFOCJyxHG7k7k",
-    "live_mode": true,
+    "live_mode": false,
     "offers": [
       {
         "allowed_passenger_identity_document_types": [
           "passport"
-        ],
-        "available_payment_types": "payments",
-        "available_services": [
-          {
-            "id": "ase_00009UhD4ongolulWd9123",
-            "maximum_quantity": 1,
-            "metadata": {
-              "type": "checked"
-            },
-            "passenger_ids": [
-              "pas_00009hj8USM7Ncg31cBCLL"
-            ],
-            "segment_ids": [
-              "seg_00009hj8USM7Ncg31cB456"
-            ],
-            "total_amount": "15.00",
-            "total_currency": "GBP",
-            "type": "baggage"
-          }
         ],
         "base_amount": "30.20",
         "base_currency": "GBP",
@@ -47,16 +28,27 @@
         "id": "off_00009htYpSCXrwaB9DnUm0",
         "live_mode": true,
         "owner": {
+          "conditions_of_carriage_url": "https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage",
           "iata_code": "BA",
           "id": "aln_00001876aqC8c5umZmrRds",
+          "logo_lockup_url": "https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg",
+          "logo_symbol_url": "https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg",
           "name": "British Airways"
         },
-        "partial": false,
+        "partial": true,
         "passenger_identity_documents_required": false,
         "passengers": [
           {
             "age": 14,
+            "family_name": "Earhart",
+            "given_name": "Amelia",
             "id": "pas_00009hj8USM7Ncg31cBCL",
+            "loyalty_programme_accounts": [
+              {
+                "account_number": "12901014",
+                "airline_iata_code": "BA"
+              }
+            ],
             "type": "adult"
           }
         ],
@@ -65,6 +57,13 @@
           "price_guarantee_expires_at": "2020-01-17T10:42:14Z",
           "requires_instant_payment": false
         },
+        "private_fares": [
+          {
+            "corporate_code": "FLX53",
+            "tracking_reference": "ABN:2345678",
+            "type": "corporate"
+          }
+        ],
         "slices": [
           {
             "conditions": {
@@ -78,38 +77,39 @@
               "airports": [
                 {
                   "city": {
-                    "iata_code": "NYC",
-                    "iata_country_code": "US",
-                    "id": "cit_nyc_us",
-                    "name": "New York"
+                    "iata_code": "LON",
+                    "iata_country_code": "GB",
+                    "id": "cit_lon_gb",
+                    "name": "London"
                   },
-                  "city_name": "New York",
-                  "iata_code": "JFK",
-                  "iata_country_code": "US",
-                  "icao_code": "KJFK",
-                  "id": "arp_jfk_us",
-                  "latitude": 40.640556,
-                  "longitude": -73.778519,
-                  "name": "John F. Kennedy International Airport",
-                  "time_zone": "America/New_York"
+                  "city_name": "London",
+                  "iata_city_code": "LON",
+                  "iata_code": "LHR",
+                  "iata_country_code": "GB",
+                  "icao_code": "EGLL",
+                  "id": "arp_lhr_gb",
+                  "latitude": 64.068865,
+                  "longitude": -141.951519,
+                  "name": "Heathrow",
+                  "time_zone": "Europe/London"
                 }
               ],
               "city": {
-                "iata_code": "NYC",
-                "iata_country_code": "US",
-                "id": "cit_nyc_us",
-                "name": "New York"
+                "iata_code": "LON",
+                "iata_country_code": "GB",
+                "id": "cit_lon_gb",
+                "name": "London"
               },
-              "city_name": "New York",
-              "iata_city_code": "NYC",
-              "iata_code": "JFK",
-              "iata_country_code": "US",
-              "icao_code": "KJFK",
-              "id": "arp_jfk_us",
-              "latitude": 40.640556,
-              "longitude": -73.778519,
-              "name": "John F. Kennedy International Airport",
-              "time_zone": "America/New_York",
+              "city_name": "London",
+              "iata_city_code": "LON",
+              "iata_code": "LHR",
+              "iata_country_code": "GB",
+              "icao_code": "EGLL",
+              "id": "arp_lhr_gb",
+              "latitude": 64.068865,
+              "longitude": -141.951519,
+              "name": "Heathrow",
+              "time_zone": "Europe/London",
               "type": "airport"
             },
             "destination_type": "airport",
@@ -126,6 +126,7 @@
                     "name": "London"
                   },
                   "city_name": "London",
+                  "iata_city_code": "LON",
                   "iata_code": "LHR",
                   "iata_country_code": "GB",
                   "icao_code": "EGLL",
@@ -172,6 +173,7 @@
                     "name": "New York"
                   },
                   "city_name": "New York",
+                  "iata_city_code": "NYC",
                   "iata_code": "JFK",
                   "iata_country_code": "US",
                   "icao_code": "KJFK",
@@ -186,14 +188,20 @@
                 "duration": "PT02H26M",
                 "id": "seg_00009htYpSCXrwaB9Dn456",
                 "marketing_carrier": {
+                  "conditions_of_carriage_url": "https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage",
                   "iata_code": "BA",
                   "id": "aln_00001876aqC8c5umZmrRds",
+                  "logo_lockup_url": "https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg",
+                  "logo_symbol_url": "https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg",
                   "name": "British Airways"
                 },
                 "marketing_carrier_flight_number": "1234",
                 "operating_carrier": {
+                  "conditions_of_carriage_url": "https://www.britishairways.com/en-gb/information/legal/british-airways/general-conditions-of-carriage",
                   "iata_code": "BA",
                   "id": "aln_00001876aqC8c5umZmrRds",
+                  "logo_lockup_url": "https://assets.duffel.com/img/airlines/for-light-background/full-color-lockup/BA.svg",
+                  "logo_symbol_url": "https://assets.duffel.com/img/airlines/for-light-background/full-color-logo/BA.svg",
                   "name": "British Airways"
                 },
                 "operating_carrier_flight_number": "4321",
@@ -205,6 +213,7 @@
                     "name": "London"
                   },
                   "city_name": "London",
+                  "iata_city_code": "LON",
                   "iata_code": "LHR",
                   "iata_country_code": "GB",
                   "icao_code": "EGLL",
@@ -228,6 +237,52 @@
                     "fare_basis_code": "OXZ0RO",
                     "passenger_id": "passenger_0"
                   }
+                ],
+                "stops": [
+                  {
+                    "airport": {
+                      "airports": [
+                        {
+                          "city": {
+                            "iata_code": "LON",
+                            "iata_country_code": "GB",
+                            "id": "cit_lon_gb",
+                            "name": "London"
+                          },
+                          "city_name": "London",
+                          "iata_city_code": "LON",
+                          "iata_code": "LHR",
+                          "iata_country_code": "GB",
+                          "icao_code": "EGLL",
+                          "id": "arp_lhr_gb",
+                          "latitude": 64.068865,
+                          "longitude": -141.951519,
+                          "name": "Heathrow",
+                          "time_zone": "Europe/London"
+                        }
+                      ],
+                      "city": {
+                        "iata_code": "LON",
+                        "iata_country_code": "GB",
+                        "id": "cit_lon_gb",
+                        "name": "London"
+                      },
+                      "city_name": "London",
+                      "iata_city_code": "LON",
+                      "iata_code": "LHR",
+                      "iata_country_code": "GB",
+                      "icao_code": "EGLL",
+                      "id": "arp_lhr_gb",
+                      "latitude": 64.068865,
+                      "longitude": -141.951519,
+                      "name": "Heathrow",
+                      "time_zone": "Europe/London",
+                      "type": "airport"
+                    },
+                    "departing_at": "2020-06-13T16:38:02",
+                    "duration": "PT02H26M",
+                    "id": "sto_00009htYpSCXrwaB9Dn456"
+                  }
                 ]
               }
             ]
@@ -238,7 +293,7 @@
         "total_amount": "45.00",
         "total_currency": "GBP",
         "total_emissions_kg": "460",
-        "updated_at": "2020-01-17T10:12:14.545Z"
+        "updated_at": "2020-01-17T10:42:14.545Z"
       }
     ],
     "passengers": [
@@ -263,38 +318,39 @@
           "airports": [
             {
               "city": {
-                "iata_code": "NYC",
-                "iata_country_code": "US",
-                "id": "cit_nyc_us",
-                "name": "New York"
+                "iata_code": "LON",
+                "iata_country_code": "GB",
+                "id": "cit_lon_gb",
+                "name": "London"
               },
-              "city_name": "New York",
-              "iata_code": "JFK",
-              "iata_country_code": "US",
-              "icao_code": "KJFK",
-              "id": "arp_jfk_us",
-              "latitude": 40.640556,
-              "longitude": -73.778519,
-              "name": "John F. Kennedy International Airport",
-              "time_zone": "America/New_York"
+              "city_name": "London",
+              "iata_city_code": "LON",
+              "iata_code": "LHR",
+              "iata_country_code": "GB",
+              "icao_code": "EGLL",
+              "id": "arp_lhr_gb",
+              "latitude": 64.068865,
+              "longitude": -141.951519,
+              "name": "Heathrow",
+              "time_zone": "Europe/London"
             }
           ],
           "city": {
-            "iata_code": "NYC",
-            "iata_country_code": "US",
-            "id": "cit_nyc_us",
-            "name": "New York"
+            "iata_code": "LON",
+            "iata_country_code": "GB",
+            "id": "cit_lon_gb",
+            "name": "London"
           },
-          "city_name": "New York",
-          "iata_city_code": "NYC",
-          "iata_code": "JFK",
-          "iata_country_code": "US",
-          "icao_code": "KJFK",
-          "id": "arp_jfk_us",
-          "latitude": 40.640556,
-          "longitude": -73.778519,
-          "name": "John F. Kennedy International Airport",
-          "time_zone": "America/New_York",
+          "city_name": "London",
+          "iata_city_code": "LON",
+          "iata_code": "LHR",
+          "iata_country_code": "GB",
+          "icao_code": "EGLL",
+          "id": "arp_lhr_gb",
+          "latitude": 64.068865,
+          "longitude": -141.951519,
+          "name": "Heathrow",
+          "time_zone": "Europe/London",
           "type": "airport"
         },
         "destination_type": "airport",
@@ -308,6 +364,7 @@
                 "name": "London"
               },
               "city_name": "London",
+              "iata_city_code": "LON",
               "iata_code": "LHR",
               "iata_country_code": "GB",
               "icao_code": "EGLL",

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -27,5 +27,6 @@ def test_http_client_error(requests_mock):
     client = HttpClient("some_token", "http://someaddress", "v1")
     with pytest.raises(
         ApiError, match="The airline responded with an unexpected error"
-    ):
+    ) as excinfo:
         client.do_get("/api/stuff")
+    assert excinfo.value.meta["request_id"] == "FmXeZifDA60QOlgAAODB"

--- a/tests/test_partial_offer_requests.py
+++ b/tests/test_partial_offer_requests.py
@@ -1,0 +1,94 @@
+import pytest
+
+from duffel_api.api import PartialOfferRequestCreate
+
+from .fixtures import fixture
+
+
+def test_get_partial_offer_request_by_id(requests_mock):
+    url = "air/partial_offer_requests/id"
+    with fixture(
+        "get-partial-offer-request-by-id", url, requests_mock.get, 200
+    ) as client:
+        offer_request = client.partial_offer_requests.get("id")
+        assert offer_request.id == "orq_00009hjdomFOCJyxHG7k7k"
+        assert len(offer_request.slices) == 1
+        assert len(offer_request.passengers) == 1
+        slice = offer_request.slices[0]
+        assert slice.origin_type == "airport"
+        assert len(offer_request.offers) == 1
+        offer = offer_request.offers[0]
+        assert offer.partial
+        assert offer.id == "off_00009htYpSCXrwaB9DnUm0"
+
+
+def test_create_partial_offer_request(requests_mock):
+    url = "air/partial_offer_requests"
+    with fixture(
+        "create-partial-offer-request", url, requests_mock.post, 201
+    ) as client:
+        passengers = [{"type": "adult"}]
+        slices = [
+            {
+                "departure_date": "2100-02-27",
+                "destination": "LGW",
+                "origin": "LIS",
+            }
+        ]
+        offer_request = (
+            client.partial_offer_requests.create()
+            .passengers(passengers)
+            .slices(slices)
+            .execute()
+        )
+        assert offer_request.id == "orq_00009hjdomFOCJyxHG7k7k"
+        assert len(offer_request.offers) == 1
+        offer = offer_request.offers[0]
+        assert offer.id == "off_00009htYpSCXrwaB9DnUm0"
+        assert offer.partial
+
+
+def test_get_partial_offer_request_fares_by_id(requests_mock):
+    url = "air/partial_offer_requests/id/fares?selected_partial_offer[]=some-partial-offer-id"  # noqa: E501
+    with fixture(
+        "get-partial-offer-request-by-id", url, requests_mock.get, 200
+    ) as client:
+        offer_request = client.partial_offer_requests.fares(
+            "id", selected_partial_offers=["some-partial-offer-id"]
+        )
+        assert offer_request.id == "orq_00009hjdomFOCJyxHG7k7k"
+        assert len(offer_request.slices) == 1
+        assert len(offer_request.passengers) == 1
+        slice = offer_request.slices[0]
+        assert slice.origin_type == "airport"
+        assert len(offer_request.offers) == 1
+        offer = offer_request.offers[0]
+        assert offer.partial
+        assert offer.id == "off_00009htYpSCXrwaB9DnUm0"
+        assert offer.tax_amount == "40.80"
+        assert offer.total_amount == "45.00"
+        assert offer.total_currency == "GBP"
+
+
+def test_create_partial_offer_request_with_invalid_data(requests_mock):
+    url = "air/partial_offer_requests"
+    with fixture(
+        "create-partial-offer-request", url, requests_mock.post, 422
+    ) as client:
+        creation = client.partial_offer_requests.create()
+        with pytest.raises(PartialOfferRequestCreate.InvalidNumberOfPassengers):
+            creation.execute()
+
+        with pytest.raises(PartialOfferRequestCreate.InvalidPassenger):
+            creation.passengers([{}]).execute()
+
+        with pytest.raises(PartialOfferRequestCreate.InvalidCabinClass):
+            creation.cabin_class("invalid").execute()
+
+        passengers = [{"type": "adult"}]
+
+        creation = creation.passengers(passengers)
+        with pytest.raises(PartialOfferRequestCreate.InvalidNumberOfSlices):
+            creation.execute()
+        with pytest.raises(PartialOfferRequestCreate.InvalidSlice):
+            creation.slices([{}]).execute()


### PR DESCRIPTION
Add support for [multi-step search](https://duffel.com/docs/guides/multi-step-search), also called the [Partial Offer Request flow](https://duffel.com/docs/api/v1/partial-offer-requests).

It has 3 main endpoints, all implemented here:
- `POST https://api.duffel.com/air/partial_offer_requests` - Create a partial offer request
- `GET https://api.duffel.com/air/partial_offer_requests/{id}` - Fetch a specific partial offer request, with support for the query param
- `GET https://api.duffel.com/air/partial_offer_requests/{id}/fares` - Get the fares as full offers, which allow you to create an order with said offer id.