### PR TITLE
Fix datetime payment requirements

### DIFF
--- a/duffel_api/models/offer.py
+++ b/duffel_api/models/offer.py
@@ -96,9 +96,7 @@ class PaymentRequirements:
         """Construct a class instance from a JSON response."""
         return cls(
             payment_required_by=get_and_transform(
-                json,
-                "payment_required_by",
-                lambda value: datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ"),
+                json, "payment_required_by", parse_datetime
             ),
             price_guarantee_expires_at=get_and_transform(
                 json,

--- a/duffel_api/models/offer.py
+++ b/duffel_api/models/offer.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Optional, Sequence
 
 from duffel_api.models import Aircraft, Airline, Airport, LoyaltyProgrammeAccount, Place
-from duffel_api.utils import get_and_transform
+from duffel_api.utils import get_and_transform, parse_datetime
 
 
 @dataclass
@@ -499,12 +499,3 @@ class Offer:
             total_currency=json["total_currency"],
             total_emissions_kg=json["total_emissions_kg"],
         )
-
-
-def parse_datetime(value: str) -> datetime:
-    # There are inconsistent formats used for this field depending on the
-    # endpoint
-    if len(value) == 20:
-        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
-    else:
-        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")

--- a/duffel_api/models/order_cancellation.py
+++ b/duffel_api/models/order_cancellation.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
 
-from duffel_api.utils import get_and_transform
+from duffel_api.utils import get_and_transform, parse_datetime
 
 
 @dataclass
@@ -57,12 +57,3 @@ class OrderCancellation:
             confirmed_at=get_and_transform(json, "confirmed_at", parse_datetime),
             created_at=datetime.strptime(json["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ"),
         )
-
-
-def parse_datetime(value: str) -> datetime:
-    # There are inconsistent formats used for this field depending on the
-    # endpoint
-    if len(value) == 20:
-        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
-    else:
-        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")

--- a/duffel_api/models/order_change.py
+++ b/duffel_api/models/order_change.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Optional, Sequence
 
 from duffel_api.models import Aircraft, Airline, Place
-from duffel_api.utils import get_and_transform
+from duffel_api.utils import get_and_transform, parse_datetime
 
 
 @dataclass
@@ -164,12 +164,3 @@ class OrderChange:
             created_at=datetime.strptime(json["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ"),
             slices=OrderChangeSlices.from_json(json["slices"]),
         )
-
-
-def parse_datetime(value: str) -> datetime:
-    # There are inconsistent formats used for this field depending on the
-    # endpoint
-    if len(value) == 20:
-        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
-    else:
-        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")

--- a/duffel_api/models/order_change_offer.py
+++ b/duffel_api/models/order_change_offer.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Optional, Sequence
 
 from duffel_api.models import Aircraft, Airline, Place, Airport
-from duffel_api.utils import get_and_transform
+from duffel_api.utils import get_and_transform, parse_datetime
 
 
 @dataclass
@@ -175,12 +175,3 @@ class OrderChangeOffer:
             expires_at=parse_datetime(json["expires_at"]),
             slices=OrderChangeOfferSlices.from_json(json["slices"]),
         )
-
-
-def parse_datetime(value: str) -> datetime:
-    # There are inconsistent formats used for this field depending on the
-    # endpoint
-    if len(value) == 20:
-        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
-    else:
-        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")

--- a/duffel_api/models/payment_intent.py
+++ b/duffel_api/models/payment_intent.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Optional, Sequence
 
 from duffel_api.models import Refund
-from duffel_api.utils import get_and_transform
+from duffel_api.utils import get_and_transform, parse_datetime
 
 
 @dataclass
@@ -62,12 +62,3 @@ class PaymentIntent:
             created_at=datetime.strptime(json["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ"),
             updated_at=datetime.strptime(json["updated_at"], "%Y-%m-%dT%H:%M:%S.%fZ"),
         )
-
-
-def parse_datetime(value: str) -> datetime:
-    # There are inconsistent formats used for this field depending on the
-    # endpoint
-    if len(value) == 20:
-        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
-    else:
-        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")

--- a/duffel_api/utils.py
+++ b/duffel_api/utils.py
@@ -1,4 +1,5 @@
 """Assorted auxiliary functions"""
+from datetime import datetime
 from typing import Any
 
 
@@ -25,3 +26,13 @@ def version() -> str:
     import pkg_resources
 
     return pkg_resources.require("duffel_api")[0].version
+
+
+def parse_datetime(value: str) -> datetime:
+    """Parse a datetime string regardless of having milliseconds or not"""
+    # There are inconsistent formats used for the field, therefore we try to accomodate
+    # instead of making an API breaking change.
+    if len(value) == 20:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+    else:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+
+import pytest
+
+from duffel_api.utils import parse_datetime
+
+
+def test_parse_datetime():
+    assert parse_datetime("2022-11-02T12:24:52Z") == datetime(2022, 11, 2, 12, 24, 52)
+    assert parse_datetime("2022-11-02T12:24:52.012Z") == datetime(
+        2022, 11, 2, 12, 24, 52, 12000
+    )
+    with pytest.raises(
+        ValueError,
+        match="time data '2022-11-02T-2:24:52Z' does not match format '%Y-%m-%dT%H:%M:%SZ'",  # noqa: E501
+    ):
+        parse_datetime("2022-11-02T-2:24:52Z")
+    with pytest.raises(
+        ValueError,
+        match="time data '2022-11-02T12:24:52' does not match format '%Y-%m-%dT%H:%M:%S.%fZ'",  # noqa: E501
+    ):
+        parse_datetime("2022-11-02T12:24:52")


### PR DESCRIPTION
In our payments date times we sometimes may return milliseconds. This makes the library cope with that inconsistency until we have consistency in our API.

Fixes #212 