### PR TITLE
Remove Python 3.7 Support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Python client library for the [Duffel API](https://duffel.com/docs/api).
 
 ## Requirements
 
-- Python 3.7+
+- Python 3.8+
 
 ## Getting started
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
         "Intended Audience :: Developers",
     ],
     keywords="duffel api flights airports airlines aircraft",
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=["requests>=2.25"],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 # keep this list in sync with .github/workflows/main.yaml
-envlist = clean,py37,py38,py39,py310,report
+envlist = clean,py38,py39,py310,report
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
Python 3.7 will be reaching end of life in ~ 4 months ([source](https://endoflife.date/python), [source](https://devguide.python.org/versions/)).