### PR TITLE
Add support and testing for python 3.11

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog] and this project adheres to [Semantic 
   [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
   [Semantic Versioning]: http://semver.org/spec/v2.0.0.html
 
+
+## [Unreleased]
+
+### Added
+- Added support and testing for Python 3.11.
+
 ## [0.5.0] - 2023-02-15
 
 ### Added

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 # keep this list in sync with .github/workflows/main.yaml
-envlist = clean,py38,py39,py310,report
+envlist = clean,py38,py39,py310,py311,report
 
 [gh-actions]
 python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 deps =


### PR DESCRIPTION
As we removed 3.7 earlier, let's add 3.11 which is something already out.