### PR TITLE
Remove usage of deprecated pkg_resources

### DIFF
--- a/duffel_api/utils.py
+++ b/duffel_api/utils.py
@@ -1,16 +1,17 @@
-"""Assorted auxiliary functions"""
+"""Assorted auxiliary functions."""
 from datetime import datetime
 from typing import Any
 
 
 def identity(value: Any) -> Any:
-    """Given a value, return the exact same value"""
+    """Given a value, return the exact same value."""
     return value
 
 
 def get_and_transform(dict: dict, key: str, fn, default=None):
-    """Get a value from a dictionary and transform it or return
-    None if the key isn't present"""
+    """Get a value from a dictionary and transform it or return None if the key isn't
+    present.
+    """
     try:
         value = dict[key]
         if value is None:
@@ -22,14 +23,14 @@ def get_and_transform(dict: dict, key: str, fn, default=None):
 
 
 def version() -> str:
-    """Return the version specified in the package (setup.py) during runtime"""
-    import pkg_resources
+    """Return the version specified in the package (setup.py) during runtime."""
+    from importlib.metadata import version
 
-    return pkg_resources.require("duffel_api")[0].version
+    return version("duffel_api")
 
 
 def parse_datetime(value: str) -> datetime:
-    """Parse a datetime string regardless of having milliseconds or not"""
+    """Parse a datetime string regardless of having milliseconds or not."""
     # There are inconsistent formats used for the field, therefore we try to accomodate
     # instead of making an API breaking change.
     if len(value) == 20:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,12 @@ from datetime import datetime
 
 import pytest
 
-from duffel_api.utils import parse_datetime
+from duffel_api.utils import parse_datetime, version
+
+
+def test_version():
+    # We only check for any content for now
+    assert version()
 
 
 def test_parse_datetime():


### PR DESCRIPTION
Per [this](https://setuptools.pypa.io/en/latest/pkg_resources.html), `pkg_resources` is deprecated. So this is a minor cleanup.