### PR TITLE
Use utility function to auto-detect correct datetime format

### DIFF
--- a/duffel_api/models/airport.py
+++ b/duffel_api/models/airport.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional, Sequence
 
-from duffel_api.utils import get_and_transform
+from duffel_api.utils import get_and_transform, parse_datetime
 
 
 @dataclass
@@ -144,6 +144,6 @@ class Refund:
             status=json["status"],
             destination=json["destination"],
             arrival=json["arrival"],
-            created_at=datetime.strptime(json["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ"),
-            updated_at=datetime.strptime(json["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ"),
+            created_at=parse_datetime(json["created_at"]),
+            updated_at=parse_datetime(json["updated_at"]),
         )

--- a/duffel_api/models/offer.py
+++ b/duffel_api/models/offer.py
@@ -99,9 +99,7 @@ class PaymentRequirements:
                 json, "payment_required_by", parse_datetime
             ),
             price_guarantee_expires_at=get_and_transform(
-                json,
-                "price_guarantee_expires_at",
-                lambda value: datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ"),
+                json, "price_guarantee_expires_at", parse_datetime
             ),
             requires_instant_payment=json["requires_instant_payment"],
         )
@@ -251,8 +249,8 @@ class OfferSliceSegment:
         return cls(
             id=json["id"],
             aircraft=get_and_transform(json, "aircraft", Aircraft.from_json),
-            arriving_at=datetime.strptime(json["arriving_at"], "%Y-%m-%dT%H:%M:%S"),
-            departing_at=datetime.strptime(json["departing_at"], "%Y-%m-%dT%H:%M:%S"),
+            arriving_at=parse_datetime(json["arriving_at"]),
+            departing_at=parse_datetime(json["departing_at"]),
             destination=Airport.from_json(json["destination"]),
             destination_terminal=json.get("destination_terminal"),
             origin=Airport.from_json(json["origin"]),
@@ -466,8 +464,8 @@ class Offer:
             base_amount=json["base_amount"],
             base_currency=json["base_currency"],
             conditions=OfferConditions.from_json(json["conditions"]),
-            created_at=datetime.strptime(json["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ"),
-            updated_at=datetime.strptime(json["updated_at"], "%Y-%m-%dT%H:%M:%S.%fZ"),
+            created_at=parse_datetime(json["created_at"]),
+            updated_at=parse_datetime(json["updated_at"]),
             expires_at=parse_datetime(json["expires_at"]),
             owner=Airline.from_json(json["owner"]),
             partial=json["partial"],

--- a/duffel_api/models/offer_request.py
+++ b/duffel_api/models/offer_request.py
@@ -3,7 +3,7 @@ from datetime import date, datetime
 from typing import Optional, Sequence, Union
 
 from duffel_api.models import Airport, City, LoyaltyProgrammeAccount, Offer
-from duffel_api.utils import get_and_transform
+from duffel_api.utils import get_and_transform, parse_datetime
 
 
 @dataclass
@@ -120,5 +120,5 @@ class OfferRequest:
                 ],
                 [],
             ),
-            created_at=datetime.strptime(json["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ"),
+            created_at=parse_datetime(json["created_at"]),
         )

--- a/duffel_api/models/order.py
+++ b/duffel_api/models/order.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Optional, Sequence, Union
 
 from duffel_api.models import Aircraft, Airline, Airport, LoyaltyProgrammeAccount, Place
-from duffel_api.utils import get_and_transform
+from duffel_api.utils import get_and_transform, parse_datetime
 
 
 @dataclass
@@ -200,8 +200,8 @@ class OrderSliceSegment:
         return cls(
             id=json["id"],
             aircraft=get_and_transform(json, "aircraft", Aircraft.from_json),
-            arriving_at=datetime.strptime(json["arriving_at"], "%Y-%m-%dT%H:%M:%S"),
-            departing_at=datetime.strptime(json["departing_at"], "%Y-%m-%dT%H:%M:%S"),
+            arriving_at=parse_datetime(json["arriving_at"]),
+            departing_at=parse_datetime(json["departing_at"]),
             destination=Airport.from_json(json["destination"]),
             destination_terminal=json.get("destination_terminal"),
             origin=Airport.from_json(json["origin"]),
@@ -420,12 +420,12 @@ class OrderPaymentStatus:
             payment_required_by=get_and_transform(
                 json,
                 "payment_required_by",
-                lambda value: datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ"),
+                parse_datetime,
             ),
             price_guarantee_expires_at=get_and_transform(
                 json,
                 "price_guarantee_expires_at",
-                lambda value: datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ"),
+                parse_datetime,
             ),
         )
 
@@ -529,14 +529,14 @@ class Order:
             cancelled_at=get_and_transform(
                 json,
                 "cancelled_at",
-                lambda value: datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ"),
+                parse_datetime,
             ),
             content=json["content"],
-            created_at=datetime.strptime(json["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ"),
+            created_at=parse_datetime(json["created_at"]),
             synced_at=get_and_transform(
                 json,
                 "synced_at",
-                lambda value: datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ"),
+                parse_datetime,
             ),
             documents=get_and_transform(
                 json,

--- a/duffel_api/models/payment.py
+++ b/duffel_api/models/payment.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
 
+from duffel_api.utils import parse_datetime
+
 
 @dataclass
 class Payment:
@@ -40,5 +42,5 @@ class Payment:
             live_mode=json["live_mode"],
             amount=json["amount"],
             currency=json.get("currency"),
-            created_at=datetime.strptime(json["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ"),
+            created_at=parse_datetime(json["created_at"]),
         )

--- a/duffel_api/utils.py
+++ b/duffel_api/utils.py
@@ -32,7 +32,14 @@ def parse_datetime(value: str) -> datetime:
     """Parse a datetime string regardless of having milliseconds or not"""
     # There are inconsistent formats used for the field, therefore we try to accomodate
     # instead of making an API breaking change.
-    if len(value) == 20:
-        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+    #
+    # I'm really not happy with this but it helps so I'm leaving it for now.
+    if value.endswith("Z"):
+        if len(value) == 20:
+            return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+        else:
+            return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+    if len(value) == 19:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
     else:
-        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,13 +10,9 @@ def test_parse_datetime():
     assert parse_datetime("2022-11-02T12:24:52.012Z") == datetime(
         2022, 11, 2, 12, 24, 52, 12000
     )
+    assert parse_datetime("2022-11-02T12:24:52") == datetime(2022, 11, 2, 12, 24, 52)
     with pytest.raises(
         ValueError,
         match="time data '2022-11-02T-2:24:52Z' does not match format '%Y-%m-%dT%H:%M:%SZ'",  # noqa: E501
     ):
         parse_datetime("2022-11-02T-2:24:52Z")
-    with pytest.raises(
-        ValueError,
-        match="time data '2022-11-02T12:24:52' does not match format '%Y-%m-%dT%H:%M:%S.%fZ'",  # noqa: E501
-    ):
-        parse_datetime("2022-11-02T12:24:52")


### PR DESCRIPTION
Fixes #271 

Alternatively we could bring in the `dateutil` library.