### PR TITLE
Bump to version 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,20 @@ The format is based on [Keep a Changelog] and this project adheres to [Semantic 
   [Semantic Versioning]: http://semver.org/spec/v2.0.0.html
 
 
-## [Unreleased]
+## [0.6.0] - 2023-05-31
 
 ### Added
 - Added support and testing for Python 3.11.
+- Removed python 3.7 support - now requires >=3.8
+- Fixed parsing of datetimes
+- Removed deprecated pkg_resources usage
+
+  [0.6.0]: https://github.com/duffelhq/duffel-api-python/releases/tag/0.6.0
 
 ## [0.5.0] - 2023-02-15
 
 ### Added
-- our new Product: [Links] 
+- our new Product: [Links]
 
   [0.5.0]: https://github.com/duffelhq/duffel-api-python/releases/tag/0.5.0
   [Links]: https://duffel.com/links

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="duffel-api",
-    version="0.5.0",
+    version="0.6.0",
     author="Duffel Engineering",
     author_email="client-libraries@duffel.com",
     description="Client library for the Duffel API",


### PR DESCRIPTION
Bumping to 0.6.0 because we're deprecating python 3.7 _slightly_ before its end of life (3 weeks or so)